### PR TITLE
Add dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ node_modules
 # Optional REPL history
 .node_repl_history
 
+# Environment file
+.env
+
 # Order file
 data/orders.yaml
 data/orders.yml

--- a/app/index.js
+++ b/app/index.js
@@ -1,3 +1,5 @@
+require("dotenv").config();
+
 exports.StageManager = require("./stagemanager.js");
 exports.CardRecorder = require("./cardrecord.js");
 exports.CardCreator = require("./cardcreator.js");

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "async": "^1.5.2",
     "chai": "^3.5.0",
     "coffee-script": "^1.10.0",
+    "dotenv": "^2.0.0",
     "instadate": "^0.1.7",
     "js-yaml": "^3.5.2",
     "minimalist": "^1.0.0",


### PR DESCRIPTION
Adds `dotenv` to the project and uses it to load environment variables from a `.env` file, which is gitignore'd.  I saw Steven doing it and it looked like a nice way to keep the env vars without having to worry too much about accidentally putting them in git.

Here for your review!  :)
