### PR TITLE
Stage manager tests and fixes

### DIFF
--- a/app/stagemanager.js
+++ b/app/stagemanager.js
@@ -83,16 +83,16 @@ method.closeUnusedStages = function(data){
 	// For each list
 	_un.each(data[1], function(trelloList){
 		if (!(_un.contains(stages, trelloList["name"]))){
-				classThis.getListCards(function(d){
-					classThis.closeList(d, trelloList["id"])
-				});
+			classThis.getListCards(trelloList["id"], function(d){
+				classThis.closeList(d, trelloList["id"])
+			});
 		};
 	});
 	return;
 }
 
-method.getListCards = function(callback){
-	this.t.get("/1/lists/"+trelloList["id"]+"/cards", function(err, data){
+method.getListCards = function(trelloID, callback){
+	this.t.get("/1/lists/"+trelloID+"/cards", function(err, data){
 		if(err) throw err;
 		callback(data);
 	});
@@ -102,7 +102,7 @@ method.closeList = function(listData, trelloID){
 	if (listData.length === 0){
 		classThis.t.put("/1/list/"+trelloID+"/closed", {value: true}, function(e, success){
 		});
-	};
+	}
 }
 
 

--- a/app/stagemanager.js
+++ b/app/stagemanager.js
@@ -70,7 +70,9 @@ method.makeAdditionalLists = function(checkedList){
 
 	Q.all(all).then(function() {
 		deferred.resolve(newLists);
-	});
+	}).catch(function(e) {
+		deferred.reject(e);
+	})
 
 	return deferred.promise;
 };

--- a/app/stagemanager.js
+++ b/app/stagemanager.js
@@ -49,16 +49,30 @@ method.checkLists = function(data){ //PASS STAGES ASYNC
 
 method.makeAdditionalLists = function(checkedList){
 	console.log("makeAdd")
+	var deferred = Q.defer();
+	var all = [ ];
+	var newLists = [ ];
+
 	_un.each(checkedList, function(list, i){
+		var listDefer = Q.defer();
+		all.push(listDefer.promise);
 		if (!list["built"]){
 			var postList = {name: list["stage"], idBoard: classThis.board, pos: i+1};
 			classThis.t.post("1/lists", postList, function(err,data){
-				if (err) throw err;
-				// console.log(data);
-				// return data;
+				if (err) {
+					listDefer.reject(err);
+				}
+				newLists.push(data);
+				listDefer.resolve();
 			});
 		}
 	});
+
+	Q.all(all).then(function() {
+		deferred.resolve(newLists);
+	});
+
+	return deferred.promise;
 };
 
 method.closeUnusedStages = function(data){

--- a/app/stagemanager.js
+++ b/app/stagemanager.js
@@ -39,7 +39,6 @@ method.getStageandBoard = function(){
 
 method.checkLists = function(data){ //PASS STAGES ASYNC
 	var checked = [];
-	console.log("check");
 	lists = _un.pluck(data[1], 'name');
 	_un.each(data[0], function(stage){
 		checked.push({"stage": stage["name"], "built": _un.contains(lists, stage["name"])});
@@ -48,7 +47,6 @@ method.checkLists = function(data){ //PASS STAGES ASYNC
 };
 
 method.makeAdditionalLists = function(checkedList){
-	console.log("makeAdd")
 	var deferred = Q.defer();
 	var all = [ ];
 	var newLists = [ ];
@@ -78,7 +76,6 @@ method.makeAdditionalLists = function(checkedList){
 };
 
 method.closeUnusedStages = function(data){
-	console.log("close");
 	stages = _un.pluck(data[0], 'name'); //Grab stage names
 	// For each list
 	_un.each(data[1], function(trelloList){
@@ -105,9 +102,7 @@ method.closeList = function(listData, trelloID){
 	}
 }
 
-
 method.orderLists = function(data){
-	console.log("order")
 	var position = 0;
 	_un.each(data[0], function(stage, i){
 		appropriateList = _un.findWhere(data[1], {name: stage["name"]})

--- a/app/stagemanager.js
+++ b/app/stagemanager.js
@@ -108,13 +108,16 @@ method.closeList = function(listData, trelloID){
 
 method.orderLists = function(data){
 	console.log("order")
+	var position = 0;
 	_un.each(data[0], function(stage, i){
 		appropriateList = _un.findWhere(data[1], {name: stage["name"]})
-		listID = appropriateList["id"];
-		classThis.t.put("1/lists/"+listID+"/pos", {value: i}, function(e, data){
-		 	if (e) {throw e};
-			// 	console.log("ordering");
-		 });
+		if(appropriateList) {
+			listID = appropriateList["id"];
+			classThis.t.put("1/lists/"+listID+"/pos", {value: position}, function(e, data) {
+				if (e) {throw e};
+			});
+			position++;
+		}
 	});
 }
 

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -113,7 +113,7 @@ describe 'app.CardRecorder', ->
   describe '.addComment', ->
     sandbox = undefined
     before ->
-      sandbox = sinon.sandbox.create().stub(trello.prototype, 'get').yieldsAsync(helpers.createCommentResp)
+      sandbox = sinon.sandbox.create().stub(trello.prototype, 'post').yieldsAsync(helpers.createCommentResp)
       return
     after ->
       sandbox.restore()

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -10,6 +10,15 @@ module.exports = {
     stub.yieldsAsync(err, callbackData);
     return stub;
   },
+  waitTicks: function(numberOfTicks, callback) {
+    if(numberOfTicks <= 0) {
+      return callback();
+    }
+
+    process.nextTick(function() {
+      module.exports.waitTicks(numberOfTicks - 1, callback);
+    });
+  },
   board: process.env.TRELLO_BPA_TEST_BOARD,
   mockfile: './test/mockfile.yaml',
   board_url: '/1/boards/' + this.board + '/lists',

--- a/test/test-stage-manager.coffee
+++ b/test/test-stage-manager.coffee
@@ -7,7 +7,26 @@ stages = helpers.expectedStageObject.stages[0].substages
 stageMgr = new app.StageManager(helpers.mockfile, helpers.board)
 
 describe 'app.StageManager', ->
-  describe '.checkLists', -> # skipping because testing async fxn callback...boooo
+  describe '.getStageandBoard', ->
+    stub = undefined
+    expected = undefined
+
+    before ->
+      stubData = { output: "data" };
+      stub = helpers.trelloStub("get", null, stubData);
+      expected = [helpers.expectedStageObject.stages[0].substages, stubData]
+
+    after ->
+      stub.restore()
+
+    it 'gets stages and lists in the trello board', (done) ->
+      stageMgr.getStageandBoard().then (data) ->
+        expect(data).to.eql expected
+        expect(stub.callCount).to.eql 1
+        done()
+      return
+    return
+
     it 'checks which stages in an object of stages are in a trello board', ->
       expected_object = ["Kanbanian", "Kanbanian-Dos"]
       stageMgr.checkLists(helpers.stubbed_list, testCallback)

--- a/test/test-stage-manager.coffee
+++ b/test/test-stage-manager.coffee
@@ -7,7 +7,7 @@ stages = helpers.expectedStageObject.stages[0].substages
 
 stageMgr = new app.StageManager(helpers.mockfile, helpers.board)
 
-timeout = 50
+timeout = 10
 
 describe 'app.StageManager', ->
   describe '.getStageandBoard', ->
@@ -154,11 +154,8 @@ describe 'app.StageManager', ->
 
     it 'asks Trello to close the list', (done) ->
       stageMgr.closeList([], 'abc123');
-      setTimeout (->
-        expect(stub.callCount).to.eql 1
-        done()
-        return
-      ), timeout
+      expect(stub.callCount).to.eql 1
+      done()
       return
     return
 
@@ -186,11 +183,8 @@ describe 'app.StageManager', ->
       # First argument: all stages
       # Second argument: all lists on the board
       stageMgr.orderLists([stages, lists])
-      setTimeout (->
-        expect(stub.callCount).to.eql 1
-        done()
-        return
-      ), timeout
+      expect(stub.callCount).to.eql 1
+      done()
       return
 
     return

--- a/test/test-stage-manager.coffee
+++ b/test/test-stage-manager.coffee
@@ -7,8 +7,6 @@ stages = helpers.expectedStageObject.stages[0].substages
 
 stageMgr = new app.StageManager(helpers.mockfile, helpers.board)
 
-timeout = 10
-
 describe 'app.StageManager', ->
   describe '.getStageandBoard', ->
     stub = undefined
@@ -105,20 +103,18 @@ describe 'app.StageManager', ->
 
     it 'gets card info for all lists that are not in the stages', (done) ->
       stageMgr.closeUnusedStages(input)
-      setTimeout (->
+      helpers.waitTicks 2, ->
         expect(getListCardsStub.callCount).to.eql input[1].length
         done()
         return
-      ), timeout
       return
 
     it 'calls close on all lists that are not in stages', (done) ->
       stageMgr.closeUnusedStages(input)
-      setTimeout (->
+      helpers.waitTicks 2, ->
         expect(closeListStub.callCount).to.eql input[1].length
         done()
         return
-      ), timeout
       return
     return
 

--- a/test/test-stage-manager.coffee
+++ b/test/test-stage-manager.coffee
@@ -7,6 +7,8 @@ stages = helpers.expectedStageObject.stages[0].substages
 
 stageMgr = new app.StageManager(helpers.mockfile, helpers.board)
 
+timeout = 50
+
 describe 'app.StageManager', ->
   describe '.getStageandBoard', ->
     stub = undefined
@@ -58,7 +60,7 @@ describe 'app.StageManager', ->
     unbuilt = undefined
 
     beforeEach ->
-      stub = helpers.trelloStub("post", error, true);
+      stub = helpers.trelloStub('post', error, true);
       unbuilt = helpers.make_lists.filter (l) ->
         return !l.built
       return
@@ -91,9 +93,9 @@ describe 'app.StageManager', ->
     closeListStub = undefined
 
     beforeEach ->
-      input = [ [], [{ name: "List", id: "abc" }] ]
-      getListCardsStub = helpers.trelloStub("get", null, [ ])
-      closeListStub = helpers.trelloStub("put", null, null)
+      input = [ [], [{ name: 'List', id: 'abc' }] ]
+      getListCardsStub = helpers.trelloStub('get', null, [ ])
+      closeListStub = helpers.trelloStub('put', null, null)
       return
 
     afterEach ->
@@ -107,7 +109,7 @@ describe 'app.StageManager', ->
         expect(getListCardsStub.callCount).to.eql input[1].length
         done()
         return
-      ), 30
+      ), timeout
       return
 
     it 'calls close on all lists that are not in stages', (done) ->
@@ -116,7 +118,7 @@ describe 'app.StageManager', ->
         expect(closeListStub.callCount).to.eql input[1].length
         done()
         return
-      ), 30
+      ), timeout
       return
     return
 
@@ -156,7 +158,7 @@ describe 'app.StageManager', ->
         expect(stub.callCount).to.eql 1
         done()
         return
-      ), 30
+      ), timeout
       return
     return
 
@@ -188,7 +190,7 @@ describe 'app.StageManager', ->
         expect(stub.callCount).to.eql 1
         done()
         return
-      ), 30
+      ), timeout
       return
 
     return


### PR DESCRIPTION
Adds some tests to the stage manager and some fixes (described below)

## Test notes
Some of the code can't be well-tested because of the way errors are handled in the asynchronous code.  Restructuring to use promises everywhere would allow us to attach a `.catch()` or `.fail()` handler to check for proper behavior in error conditions.

## Code changes
* Made `makeAdditionalLists` promisified.  The promise it returns will reject if any of the lists fail to create, and will resolve after all lists have successfully been created.
* The `getListCards` method was not receiving a list ID, so I added another argument for that.  Also updated `closeUnusedStages` to pass that list ID in.
* Made `orderLists` order lists absolutely, instead of based on where its stage is in the list of stages.  That is, if there are stages A, B, C, D, and E, but there are only lists for A, D, and E, the lists will be ordered A-1, D=2, E=3, instead of A=1,D=4,E=5.  ***This isn't a bug and I meant to ask you about it before I committed it, but then I committed it and forgot to ask you about it first.  If you don't like this behavior, I'll revert it back, and I promise to try to do better about communicating!***
* Changed the `addComment` test in `test-card-recorder` to mock the node-trello POST method instead of GET.  The result was an invalid ID being passed into the node-trello method which was causing some kind of weird asynchronous exception.  Unrelated tests were randomly appearing to fail.