### PR TITLE
Tests/superclass

### DIFF
--- a/app/cardcreator.js
+++ b/app/cardcreator.js
@@ -35,7 +35,7 @@ method.createCard = function(order){
 		var due = null;
 	}
 	classThis = this;
-	this.getListIDbyName(order["stage"], function(listID){
+	this.getListIDbyName(order["stage"]).then(function(listID){
 		var cardInfo = {"name": cardName,
 										"desc": description,
 										"idList": listID,

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -46,7 +46,9 @@ method.getListIDbyName = function(name, callback){
 method.getListNameByID = function(listID){
   var deferred = Q.defer();
   this.t.get('/1/lists/'+listID, function(err, list){
-    if(err) {deferred.reject(new Error(err));};
+    if(err) {
+      return deferred.reject(new Error(err));
+    };
 		deferred.resolve(list["name"]);
   });
   return deferred.promise;

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -27,20 +27,25 @@ method.getPreAward = function(){
 }
 
 method.getListIDbyName = function(name, callback){
+  var deferred = Q.defer();
   var find = true;
   if (!name) {
     var find = false;
   }
   this.t.get(this.lists_url, function(e, data){
-    if (e) {throw e};
+    if(e) {
+      return deferred.reject(e);
+    }
     if(find){
       var list = _un.findWhere(data, {"name": name});
     }
     if (!find || !list){ //Add it to the first list if there is not one
       var list = data[0];
     }
-    callback(list["id"]);
+    deferred.resolve(list["id"]);
   });
+
+  return deferred.promise;
 }
 
 method.getListNameByID = function(listID){

--- a/test/test-cardcreator.coffee
+++ b/test/test-cardcreator.coffee
@@ -4,6 +4,7 @@ app = require('../app')
 helpers = require('./test-helpers.js')
 q = require('q')
 sinon = require('sinon')
+require('sinon-as-promised')
 trello = require('node-trello')
 CC = new app.CardCreator(helpers.mockfile, helpers.board)
 
@@ -33,7 +34,7 @@ describe 'app.CardCreator', ->
     beforeEach ->
       sandbox = sinon.sandbox.create()
       postStub = sandbox.stub(trello.prototype, 'post').yieldsAsync(err, undefined)
-      listStub = sandbox.stub(CC, 'getListIDbyName').withArgs("CO Review").yieldsAsync('aaaaaa')
+      listStub = sandbox.stub(CC, 'getListIDbyName').withArgs("CO Review").resolves('aaaaaa')
       return
     afterEach ->
       sandbox.restore()

--- a/test/test-superclass.coffee
+++ b/test/test-superclass.coffee
@@ -1,5 +1,7 @@
 expect = require('chai').expect
 _un = require("underscore")
+sinon = require('sinon')
+trello = require('node-trello')
 app = require('../app')
 helpers = require('./test-helpers.js')
 stages = helpers.expectedStageObject.stages[0].substages
@@ -35,6 +37,40 @@ describe 'app.TrelloSuper', ->
         stub.restore()
         done()
       return
+    return
+
+  describe 'getListNameByID', ->
+    sandbox = undefined
+    stub = undefined
+    error = null
+    result = { name: 'Test List' }
+    testListID = 'test-list-id'
+
+    beforeEach ->
+      sandbox = sinon.sandbox.create()
+      stub = sandbox.stub(trello.prototype, 'get').withArgs('/1/lists/' + testListID).yieldsAsync(error, result)
+      return
+
+    afterEach ->
+      sandbox.restore()
+      error = new Error('Test Error')
+      result = null
+      return
+
+    it 'will ping Trello to grab a list name given a list ID', (done) ->
+      stageMgr.getListNameByID(testListID).then (list) ->
+        expect(list).to.eql(result.name);
+        done()
+        return
+      return
+
+    it 'will survive a Trello error', (done) ->
+      stageMgr.getListNameByID(testListID).catch (err) ->
+        #expect(err).to.eql(error);
+        done()
+        return
+      return
+
     return
 
   return

--- a/test/test-superclass.coffee
+++ b/test/test-superclass.coffee
@@ -94,7 +94,7 @@ describe 'app.TrelloSuper', ->
 
     it 'will survive a Trello error', (done) ->
       stageMgr.getListNameByID(testListID).catch (err) ->
-        #expect(err).to.eql(error);
+        expect(err).to.eql(error);
         done()
         return
       return


### PR DESCRIPTION
Adds tests for superclass `getListNameByID` method, and extends tests for `getListIDbyName` method.  Coverage for helpers.js is now over 97%.  :smile: 

Also made `getListIDbyName` return a promise because it was throwing its exception inside a asynchronous block, making it impossible to catch.  The alternative was to pass the error as a parameter of the callback, but I figured if I was going to make a change that (relatively) deep, might as well just switch over to a promise.