### PR TITLE
Tests/cardrecord

### DIFF
--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -16,55 +16,65 @@ util.inherits(CardRecorder, TrelloSuper);
 var method = CardRecorder.prototype;
 
 method.run = function(callback){
-	this.getUpdateCards(function(card){
-		classThis.deleteCurrentComment(card["id"]).then(function(d){
-			var now = moment();
-			var daysSinceUpdate = now.diff(moment(card.actions[0].date), 'days');
-			hasMoved = classThis.hasMovedCheck(card["actions"]);
-			if (hasMoved) {//((daysSinceUpdate > 0 ) && (!hasMoved)){
-				console.log("Write New Phase: "+card["name"]);
-				var lastPhase = classThis.getLastList(card.actions[0]);
-				classThis.compileCommentArtifact(card["id"], lastPhase, lastPhase, card.actions[1].date, card.actions[0].date, callback);
-			} else if(daysSinceUpdate > 0) {
-				console.log("Write Current Comment: "+card["name"]);
-				classThis.getListNameByID(card["idList"]).then(function(listName){
-						classThis.compileCommentArtifact(card["id"], listName, "Current", card.actions[0].date, now.format(), callback);
-				});
-			}
+	this.getUpdateCards().then(function(cards){
+		_un.each(cards, function(card) {
+			classThis.deleteCurrentComment(card["id"]).then(function(d){
+				var now = moment();
+				var daysSinceUpdate = now.diff(moment(card.actions[0].date), 'days');
+				hasMoved = classThis.hasMovedCheck(card["actions"]);
+				if (hasMoved) {
+					console.log("Write New Phase: "+card["name"]);
+					var lastPhase = classThis.getLastList(card.actions[0]);
+					classThis.compileCommentArtifact(card["id"], lastPhase, lastPhase, card.actions[1].date, card.actions[0].date, callback);
+				} else if(daysSinceUpdate > 0) {
+					console.log("Write Current Comment: "+card["name"]);
+					classThis.getListNameByID(card["idList"]).then(function(listName){
+							classThis.compileCommentArtifact(card["id"], listName, "Current", card.actions[0].date, now.format(), callback);
+					});
+				}
+			});
 		});
 	});
 }
 
 method.getUpdateCards = function(callback){
+	var deferred = Q.defer();
 	classThis.t.get('/1/boards/'+this.board+'/cards', {actions: ["createCard", "updateCard"]}, function(err, cards){
-		if (err) {throw err};
-		_un.each(cards, function(card){
-			callback(card);
-		});
+		if (err) {
+			return deferred.reject(err);
+		}
+		deferred.resolve(cards);
 	});
-}
+	return deferred.promise;
+};
 
 method.deleteCurrentComment = function(cardID){
 	var deferred = Q.defer();
 	var currentCommentID = "";
 	classThis.t.get('/1/cards/'+cardID+'/actions', {filter:'commentCard'}, function(err, comments){
-		if(err) {deferred.reject(new Error(err));};
+		if(err) {
+			return deferred.reject(new Error(err));
+		}
+
 		_un.each(comments,function(c){
-			if (c.data.text.indexOf("**Current Stage:**") !== -1){
+			if (c.data.text.indexOf("**Current Stage**") !== -1){
 				currentCommentID = c["id"];
 			}
 		});
+
 		if(currentCommentID != ""){
 			classThis.t.del('/1/actions/'+currentCommentID, function(err, data){
-				if(err) { console.log(err);
-					deferred.reject(new Error(err))};
-				deferred.resolve(data);
+				if(err) {
+					console.log(err);
+					deferred.reject(new Error(err));
+				}
+				return deferred.resolve(data);
 			});
 		} else {
-			deferred.resolve("no current comment");
+			return deferred.resolve("no current comment");
 		}
 	});
-		return deferred.promise;
+	return deferred.promise;
 }
 
 method.hasMovedCheck = function(actionList){
@@ -91,7 +101,7 @@ method.compileCommentArtifact = function(cardID, dateList, nameList, fromDate, t
 		var differenceFromExpected = diffArray[0];
 		var timeTaken = diffArray[1];
 		var comment = this.buildComment(differenceFromExpected, expectedTime, fromDate, toDate, nameList, timeTaken);
-		this.addComment(comment, cardID, callback);
+		this.addComment(comment, cardID).then(callback);
 }
 
 method.calculateDateDifference = function(expected, lastMove, recentMove){
@@ -108,11 +118,15 @@ method.buildComment = function(dateDiff, expected, lastMove, recentMove, lastLis
 	return msg;
 }
 
-method.addComment = function(message, cardID, callback){
+method.addComment = function(message, cardID){
+	var deferred = Q.defer();
 	this.t.post("1/cards/"+cardID+"/actions/comments", {text: message}, function(err, data){
-		if (err) {throw err}
-		callback(data);
+		if (err) {
+			return deferred.reject(err);
+		}
+		deferred.resolve(data);
 	 });
+	 return deferred.promise;
 }
 
 module.exports = CardRecorder;

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -22,12 +22,12 @@ method.run = function(callback){
 				var now = moment();
 				var daysSinceUpdate = now.diff(moment(card.actions[0].date), 'days');
 				hasMoved = classThis.hasMovedCheck(card["actions"]);
-				if (hasMoved) {
+				if (hasMoved && daysSinceUpdate < 1) {
 					console.log("Write New Phase: "+card["name"]);
 					var lastPhase = classThis.getLastList(card.actions[0]);
 					classThis.compileCommentArtifact(card["id"], lastPhase, lastPhase, card.actions[1].date, card.actions[0].date, callback);
-				} else if(daysSinceUpdate > 0) {
-					console.log("Write Current Comment: "+card["name"]);
+				} else {
+					console.log("Write Current Phase: "+card["name"]);
 					classThis.getListNameByID(card["idList"]).then(function(listName){
 							classThis.compileCommentArtifact(card["id"], listName, "Current", card.actions[0].date, now.format(), callback);
 					});

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -57,7 +57,7 @@ method.deleteCurrentComment = function(cardID){
 		}
 
 		_un.each(comments,function(c){
-			if (c.data.text.indexOf("**Current Stage**") !== -1){
+			if (c.data.text.indexOf("**Current Stage:**") !== -1){
 				currentCommentID = c["id"];
 			}
 		});

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -21,15 +21,15 @@ method.run = function(callback){
 			var now = moment();
 			var daysSinceUpdate = now.diff(moment(card.actions[0].date), 'days');
 			hasMoved = classThis.hasMovedCheck(card["actions"]);
-			if ((daysSinceUpdate > 0 ) || (!hasMoved)){
+			if (hasMoved) {//((daysSinceUpdate > 0 ) && (!hasMoved)){
+				console.log("Write New Phase: "+card["name"]);
+				var lastPhase = classThis.getLastList(card.actions[0]);
+				classThis.compileCommentArtifact(card["id"], lastPhase, lastPhase, card.actions[1].date, card.actions[0].date, callback);
+			} else if(daysSinceUpdate > 0) {
 				console.log("Write Current Comment: "+card["name"]);
 				classThis.getListNameByID(card["idList"]).then(function(listName){
 						classThis.compileCommentArtifact(card["id"], listName, "Current", card.actions[0].date, now.format(), callback);
 				});
-			} else {
-				console.log("Write New Phase: "+card["name"]);
-				var lastPhase = classThis.getLastList(card.actions[0]);
-				classThis.compileCommentArtifact(card["id"], lastPhase, lastPhase, lists, card.actions[1].date, card.actions[0].date, callback);
 			}
 		});
 	});

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -103,7 +103,7 @@ describe 'app.CardRecorder', ->
 
     beforeEach ->
       currentComment = JSON.parse(JSON.stringify(helpers.mockCurrentComment))
-      currentComment.data.text = "**Current Stage** This comment says current stage."
+      currentComment.data.text = "**Current Stage:** This comment says current stage."
       notCurrentComment = JSON.parse(JSON.stringify(helpers.mockCurrentComment))
       notCurrentComment.data.text = "This comment is not in the current stage."
       notCurrentComment.id = 'not-current'

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -36,7 +36,14 @@ describe 'app.CardRecorder', ->
       return
 
     it 'will run the cardRecorder class for a list that has moved', (done) ->
-      getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', actions: helpers.actionListMove}])
+      # Set the action date to less than a day ago
+      # to trigger the phase change
+      cardActions = helpers.actionListMove
+      cardActions.forEach (action) ->
+        action.date = (new Date(Date.now() - 21600000)).toISOString();
+        return
+
+      getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', actions: cardActions}])
       CR.run ->
         expect(deleteCards.callCount).to.equal 1
         expect(compileStub.callCount).to.equal 1


### PR DESCRIPTION
* Promisify getUpdateCards and addComment (both were throwing asynchronous errors that were impossible to capture, so I wrapped them in promises and had them reject instead)
* 100% coverage for cardrecord

Please double-check the logic change I made here.  It seemed to me that this should be an `&&` since you would only want to update the "current" phase if it has not moved _and_ time has passed.  If it _has_ moved, you want to change the phase.  So, to simplify the logic, I reversed them.  It's easier to read what it's doing, but I'm not 100% sure this is the desired behavior.  The tests still pass, though!

```js
if ((daysSinceUpdate > 0 ) || (!hasMoved)){
    console.log("Write Current Comment: "+card["name"]);
    ...
} else {
    console.log("Write New Phase: "+card["name"]);
    ...
}
```

to

```js
if (hasMoved) {
    console.log("Write New Phase: "+card["name"]);
    ...
} else if(daysSinceUpdate > 0) {
    console.log("Write Current Comment: "+card["name"]);
    ...
}
```