### PR TITLE
Full coverage

### DIFF
--- a/app/cardcreator.js
+++ b/app/cardcreator.js
@@ -28,24 +28,24 @@ method.createCard = function(order){
 	var deferred = Q.defer();
 	var description = this.descriptionMaker(order);
 	var cardName = order["project"] +" - "+order["order"];
+	var due = null;
 
 	if (order["due"]){
-		var due = order["due"];
-	} else {
-		var due = null;
+		due = order["due"];
 	}
-	classThis = this;
-	this.getListIDbyName(order["stage"]).then(function(listID){
+
+	classThis.getListIDbyName(order["stage"]).then(function(listID){
 		var cardInfo = {"name": cardName,
 										"desc": description,
 										"idList": listID,
 										"due": due
 									};
 		classThis.t.post('1/cards/', cardInfo, function(err, data){
-			if(err) {deferred.reject(new Error(err));};
+			if(err) {
+				return deferred.reject(new Error(err));
+			}
 			deferred.resolve(data);
 		});
-
 	});
 	return deferred.promise;
 }

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -111,7 +111,9 @@ method.buildComment = function(dateDiff, expected, lastMove, recentMove, lastLis
 method.addComment = function(message, cardID, callback){
 	this.t.post("1/cards/"+cardID+"/actions/comments", {text: message}, function(err, data){
 		if (err) {throw err}
-		callback(data);
+		if(callback) {
+			callback(data);
+		}
 	 });
 }
 

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -111,9 +111,7 @@ method.buildComment = function(dateDiff, expected, lastMove, recentMove, lastLis
 method.addComment = function(message, cardID, callback){
 	this.t.post("1/cards/"+cardID+"/actions/comments", {text: message}, function(err, data){
 		if (err) {throw err}
-		if(callback) {
-			callback(data);
-		}
+		callback(data);
 	 });
 }
 

--- a/test/test-cardcreator.coffee
+++ b/test/test-cardcreator.coffee
@@ -10,46 +10,52 @@ CC = new app.CardCreator(helpers.mockfile, helpers.board)
 
 describe 'app.CardCreator', ->
   sandbox = undefined
-  before ->
+  beforeEach ->
     sandbox = sinon.sandbox.create()
-    postStub = sandbox.stub(CC, 'createOrders').yieldsAsync(helpers.testCard)
     return
 
-  after ->
+  afterEach ->
     sandbox.restore()
-    err = new Error('Test error')
     return
+
   describe '.createOrders', ->
-    it 'will take a yaml file of orders and create cards for every order', ->
-      CC.createOrders helpers.orderMockFile, (resp) ->
-        expect(resp).to.equal(helpers.testCard)
+    createCardStub = undefined
+
+    beforeEach ->
+      createCardStub = sandbox.stub(CC, 'createCard').resolves()
+      return
+
+    it 'will take a yaml file of orders and create cards for every order', (done) ->
+      CC.createOrders(helpers.orderMockFile).then (resp) ->
+        # This should be called once per order in the mock order file
+        expect(createCardStub.callCount).to.eql 1
+        done()
         return
       return
     return
 
   describe '.createCard', ->
     postStub = undefined
-    sandbox = undefined
     err = null
     beforeEach ->
-      sandbox = sinon.sandbox.create()
-      postStub = sandbox.stub(trello.prototype, 'post').yieldsAsync(err, undefined)
+      postStub = sandbox.stub(trello.prototype, 'post').yieldsAsync(err, helpers.testCard)
       listStub = sandbox.stub(CC, 'getListIDbyName').withArgs("CO Review").resolves('aaaaaa')
       return
     afterEach ->
-      sandbox.restore()
       err = new Error('Test Error')
       return
 
-    it 'will create an individual card on trello',  ->
+    it 'will create an individual card on trello', (done) ->
       CC.createCard(helpers.mockOrder).then (resp) ->
         expect(resp).to.equal(helpers.testCard)
+        done()
         return
       return
 
-    it 'survives a trello error', ->
+    it 'survives a trello error', (done) ->
       CC.createCard(helpers.mockOrder).catch ->
         expect(postStub.callCount).to.eql 1
+        done()
         return
       return
     return

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -42,7 +42,8 @@ module.exports = {
     stage: "CO Review",
     open_date: "",
     close_date: "",
-    owner: "Toni Coltona"
+    owner: "Toni Coltona",
+    due: "Tomorrow"
   },
   mockCurrentComment: {
     id: "0",


### PR DESCRIPTION
* Refactored slightly (move `var due` up to avoid declaration inside a block)
* Fixed an issue where a promise would reject and then resolve by adding a `return`
* Create and restore the sinon sandbox in a higher-level `beforeEach`/`afterEach`, instead of at each test.  If this is cool, maybe we should go back and do it in the other tests?
* Added a `due` property to the mockOrder to get complete coverage