### PR TITLE
Feature/not mean card recorder. Closes #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ Or run the cli.
 - -r   Run the card recorder with an optional stages file parameter. Without the file it will default to `data/stages.yaml`.   
 - -c   Run the card creator with an optional stages file parameter. Without the file it will default to `data/stages.yaml`.
 
-- -i To allow the use of a Trello board ID other than the one included in the .env file. 
+- -i To allow the use of a Trello board ID other than the one included in the .env file.
 
-##### Coming Soon
-
-Soon there will be a server to run the cardrecorder.
+- -b to run the build comment command line utility. Use the following flags -d "Name of List" -f "MM/DD/YYYY" -t "MM/DD/YYYY".
 
 ### Development
 Use the `develop` branch

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -115,12 +115,15 @@ class CardRecorder extends MyTrello {
       var myRegex = /(\d\d\/\d\d\/201\d) - \d\d\/\d\d\/201\d/;
       var correctComment = _.find(commentList, function(comment){
           var match = myRegex.exec(comment.data.text);
-          return match[1];
+          return match ? match[1] : false;
       });
-      var commentDateMatch = myRegex.exec(correctComment.data.text);
-      var commentDate = commentDateMatch[1];
-      return commentDate;
-
+      if(correctComment){
+        var commentDateMatch = myRegex.exec(correctComment.data.text);
+        var commentDate = commentDateMatch[1];
+        return commentDate;
+      } else {
+        return false
+      }
     }
 
     // hasMovedCheck(actionList) {

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -44,9 +44,9 @@ class CardRecorder extends MyTrello {
                             lastPhase,
                             updateActions[1].date,
                             moment(lastMove, "MM/DD/YYYY").format(),
-                            true,
-                            deferred.resolve({})
-                        );
+                            true
+                        )
+                        .then(deferred.resolve);
                     } else {
                         console.log("Write Current Phase: " + card.name);
                         self.getListNameByID(card.idList).then(function(listName) {
@@ -56,10 +56,11 @@ class CardRecorder extends MyTrello {
                                 "Current",
                                 moment(lastMove, "MM/DD/YYYY").format(),
                                 now.format(),
-                                true,
-                                deferred.resolve({})
-                            );
-                        });
+                                true
+                            )
+                        })
+                        .then(deferred.resolve);
+
                     }
                 });
             });
@@ -153,7 +154,7 @@ class CardRecorder extends MyTrello {
     findHolidaysBetweenDates(fromDate, toDate){
       var count = 0;
       _un.each(holidays, function(holiday){
-        if(moment(holiday.dateString).isBetween(fromDate, toDate, 'day')){
+        if(moment(holiday.dateString, "YYYY-M-D").isBetween(fromDate, toDate, 'day')){
           count++;
         }
       });

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -30,13 +30,20 @@ class CardRecorder extends MyTrello {
                     var updateActions = _.filter(card.actions, {type: "updateCard"});
                     if(updateActions){
                       var hasMoved = true;
+                      if(updateActions.length == 1){
+                        var createAction = _.filter(card.actions, {type: "createCard"});
+                        updateActions.push(createAction)
+                      }
                     }
                     var lastMove = self.findLastMoveDateFromComments(comments);
                     var fromMove;
                     if(lastMove){
                       fromMove = moment(lastMove, "MM/DD/YYYY").format();
-                    } else {
+                    } else if(updateActions){
                       fromMove = moment(updateActions[0].date)
+                    } else {
+                      cardCreation = _.filter(card.actions, {type: "createCard"});
+                      fromMove = moment(cardCreation.date);
                     }
                     var daysSinceUpdate = now.diff(fromMove, 'days');
                     // var hasMoved = self.hasMovedCheck(updateActions);

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -37,7 +37,7 @@ class CardRecorder extends MyTrello {
                     var daysSinceUpdate = now.diff(lastMove, 'days');
                     if (hasMoved && daysSinceUpdate < 1) {
                         console.log("Write New Phase: " + card.name);
-                        var lastPhase = self.getLastList(card.actions[0]);
+                        var lastPhase = self.getLastList(hasMoved[0]);
                         self.compileCommentArtifact(
                             card.id,
                             lastPhase,
@@ -138,7 +138,7 @@ class CardRecorder extends MyTrello {
         var moves = _.filter(actionList, function(a) {
             return 'listBefore' in a.data;
         });
-        if (moves.length) updated = true;
+        if (moves.length) updated = moves;
         return updated;
     }
 

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -75,7 +75,7 @@ class CardRecorder extends MyTrello {
         return deferred.promise;
     }
 
-    getUpdateCards(callback) {
+    getUpdateCards() {
         var deferred = Q.defer();
         var url = '/1/boards/' + this.board + '/cards';
 

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -19,7 +19,7 @@ class CardRecorder extends MyTrello {
         this.stages = this.getPreAward();
     }
 
-    run(callback) {
+    run() {
         var self = this;
         var deferred = Q.defer();
         this.getUpdateCards().then(function(cards) {
@@ -32,7 +32,13 @@ class CardRecorder extends MyTrello {
                       var hasMoved = true;
                     }
                     var lastMove = self.findLastMoveDateFromComments(comments);
-                    var daysSinceUpdate = now.diff(moment(lastMove, "MM/DD/YYYY"), 'days');
+                    var fromMove;
+                    if(lastMove){
+                      fromMove = moment(lastMove, "MM/DD/YYYY").format();
+                    } else {
+                      fromMove = moment(updateActions[0].date)
+                    }
+                    var daysSinceUpdate = now.diff(fromMove, 'days');
                     // var hasMoved = self.hasMovedCheck(updateActions);
 
                     if (hasMoved && daysSinceUpdate < 1) {
@@ -43,7 +49,7 @@ class CardRecorder extends MyTrello {
                             lastPhase,
                             lastPhase,
                             updateActions[1].date,
-                            moment(lastMove, "MM/DD/YYYY").format(),
+                            fromMove,
                             true
                         )
                         .then(deferred.resolve);
@@ -54,12 +60,12 @@ class CardRecorder extends MyTrello {
                                 card.id,
                                 listName,
                                 "Current",
-                                moment(lastMove, "MM/DD/YYYY").format(),
+                                fromMove,
                                 now.format(),
                                 true
                             )
                         })
-                        .then(deferred.resolve);
+                        .then(function(resp){deferred.resolve;});
 
                     }
                 });
@@ -113,7 +119,6 @@ class CardRecorder extends MyTrello {
       });
       var commentDateMatch = myRegex.exec(correctComment.data.text);
       var commentDate = commentDateMatch[1];
-      console.log(commentDate);
       return commentDate;
 
     }
@@ -144,7 +149,7 @@ class CardRecorder extends MyTrello {
         var comment = this.buildComment(differenceFromExpected, expectedTime, fromDate, toDate, nameList, timeTaken);
 
         if (addCommentOpt) {
-            this.addComment(comment, cardID).then(deferred.resolve);
+            this.addComment(comment, cardID).then(function(resp){deferred.resolve});
         } else {
             deferred.resolve(comment);
         }

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -65,7 +65,7 @@ class CardRecorder extends MyTrello {
                                 true
                             )
                         })
-                        .then(function(resp){deferred.resolve;});
+                        .then(deferred.resolve);
 
                     }
                 });
@@ -149,7 +149,7 @@ class CardRecorder extends MyTrello {
         var comment = this.buildComment(differenceFromExpected, expectedTime, fromDate, toDate, nameList, timeTaken);
 
         if (addCommentOpt) {
-            this.addComment(comment, cardID).then(function(resp){deferred.resolve});
+            this.addComment(comment, cardID).then(function(resp){deferred.resolve(resp)});
         } else {
             deferred.resolve(comment);
         }

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -32,13 +32,9 @@ class CardRecorder extends MyTrello {
                     if(typeof updateActions !== "undefined"){
                       hasMoved = self.hasMovedCheck(updateActions);
                     }
-                    console.log("past updateActions");
                     var lastMove = self.findLastMoveDateFromComments({commentList: comments, "actionList": updateActions, "createActionDate": createAction.date});
                     var now = moment();
                     var daysSinceUpdate = now.diff(lastMove, 'days');
-                    console.log(daysSinceUpdate);
-                    // var hasMoved = self.hasMovedCheck(updateActions);
-                    console.log("up to last move");
                     if (hasMoved && daysSinceUpdate < 1) {
                         console.log("Write New Phase: " + card.name);
                         var lastPhase = self.getLastList(card.actions[0]);
@@ -123,7 +119,7 @@ class CardRecorder extends MyTrello {
       if(correctComment){
         var commentDateMatch = myRegex.exec(correctComment.data.text);
         var commentDate = commentDateMatch[1];
-        return moment(commentDate, "MM/DD/YYYY").format();
+        return moment(commentDate, "MM/DD/YYYY").toISOString();
       } else if(actionList) {
         if(actionList.length > 1){
         return actionList[0].date;
@@ -132,7 +128,7 @@ class CardRecorder extends MyTrello {
         if(opts.cardCreationDate){
           return cardCreationDate;
         } else {
-          return moment("01/01/2016", "MM/DD/YYYY").format();
+          return moment("01/01/2016", "MM/DD/YYYY").toISOString();
         }
       }
     }

--- a/app/my-trello.js
+++ b/app/my-trello.js
@@ -30,7 +30,7 @@ class MyTrello {
         return stages ? stages.stages[0].substages : [];
     }
 
-    getListIDbyName(name, callback) {
+    getListIDbyName(name) {
         var deferred = Q.defer();
         var find = Boolean(name);
 

--- a/cli.js
+++ b/cli.js
@@ -38,5 +38,5 @@ if ("b" in argv) {
   console.log("--Build a Comment--");
   var file  = (argv["b"]=== true) ? 'data/stages.yaml' : argv["d"];
   var CR = new app.CardRecorder(file, board);
-  CR.compileCommentArtifact(null, argv.d, argv.d, argv.f, argv.t, false, console.log);
+  CR.compileCommentArtifact(null, argv.d, argv.d, argv.f, argv.t, false).then(function(comment){console.log(comment)});
 }

--- a/cli.js
+++ b/cli.js
@@ -29,8 +29,9 @@ if ("r" in argv) {
 if ("c" in argv) {
   console.log("--Invoke Card Creator--");
   var file  = (argv["c"]=== true) ? 'data/stages.yaml' : argv["c"];
+  var orders  = (argv["o"]=== true) ? 'data/orders.yaml' : argv["o"];
   var CC = new app.CardCreator(file, board);
-  CC.createOrders('data/orders.yaml');
+  CC.createOrders(orders).then(console.log("--Card Creator Complete--"));
 }
 
 if ("b" in argv) {

--- a/cli.js
+++ b/cli.js
@@ -23,7 +23,7 @@ if ("r" in argv) {
   console.log("--Invoke Card Recorder--");
   var file  = (argv["r"]=== true) ? 'data/stages.yaml' : argv["r"];
   var CR = new app.CardRecorder(file, board);
-  CR.run(console.log("CR Complete"));
+  CR.run().then(console.log("CR Complete"));
 }
 
 if ("c" in argv) {

--- a/server.js
+++ b/server.js
@@ -12,5 +12,5 @@ var j = cron.scheduleJob('0 8 * * *', function(){
   var file  = (argv["f"]) ? argv["f"] : 'data/stages.yaml';
   console.log("Running Card Recorder");
   var CR = new app.CardRecorder(file, board);
-  CR.run();
+  CR.run().then(console.log("Card Recorder Run"));
 });

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -201,8 +201,7 @@ describe 'app.CardRecorder', ->
         done()
         return
       return
-
-  return
+    return
 
   describe '.findHolidaysBetweenDates', ->
     it 'will not find a holiday between dates that do not have a holiday between them', ->

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -46,7 +46,7 @@ describe 'app.CardRecorder', ->
         return
 
       getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', name: 'BPA Project - Phase II', actions: cardActions}])
-      CR.run().then (resp) ->
+      CR.run().then ->
         expect(getCards.callCount).to.equal 1
         expect(deleteCards.callCount).to.equal 1
         expect(compileStub.callCount).to.equal 1
@@ -173,7 +173,7 @@ describe 'app.CardRecorder', ->
       return
     return
 
-  describe '.compileCommentArtifact', ->
+  describe '.compileCommentArtifact(cardID, dateList, nameList, fromDate, toDate, addCommentOpt)', ->
     sandbox = undefined
     addComment = undefined
     beforeEach ->
@@ -185,21 +185,22 @@ describe 'app.CardRecorder', ->
       sandbox.restore()
       return
 
-  it 'will run the date diff functions, build and post a comment', (done) ->
-    CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', true).then (comment) ->
-      expect(addComment.calledWith('**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.')).to.be.ok
-      expect(addComment.callCount).to.equal 1
-      done()
+    it 'will run the date diff functions, build and post a comment', (done) ->
+      commentPromise = CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', true)
+      commentPromise.done (resp) ->
+        expect(addComment.calledWith('**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.')).to.be.ok
+        expect(addComment.callCount).to.equal 1
+        done()
+        return
       return
-    return
 
-  it 'will run the date diff functions, but not actually create a comment', (done) ->
-    CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', false).then (comment) ->
-      expect(comment).to.eql '**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.'
-      expect(addComment.callCount).to.equal 0
-      done()
+    it 'will run the date diff functions, but not actually create a comment', (done) ->
+      CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', false).then (comment) ->
+        expect(comment).to.eql '**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.'
+        expect(addComment.callCount).to.equal 0
+        done()
+        return
       return
-    return
 
   return
 

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -184,21 +184,24 @@ describe 'app.CardRecorder', ->
     afterEach ->
       sandbox.restore()
       return
-    it 'will run the date diff functions, build and post a comment', (done) ->
-      CR.compileCommentArtifact 'xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', true, ->
-        expect(addComment.calledWith('**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.')).to.be.ok
-        expect(addComment.callCount).to.equal 1
-        done()
-        return
-      return
-    it 'will run the date diff functions, but not actually create a comment', (done) ->
-      CR.compileCommentArtifact 'xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', false, (comment) ->
-        expect(comment).to.eql '**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.'
-        expect(addComment.callCount).to.equal 0
-        done()
-        return
+
+  it 'will run the date diff functions, build and post a comment', (done) ->
+    CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', true).then (comment) ->
+      expect(addComment.calledWith('**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.')).to.be.ok
+      expect(addComment.callCount).to.equal 1
+      done()
       return
     return
+
+  it 'will run the date diff functions, but not actually create a comment', (done) ->
+    CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', false).then (comment) ->
+      expect(comment).to.eql '**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.'
+      expect(addComment.callCount).to.equal 0
+      done()
+      return
+    return
+
+  return
 
   describe '.findHolidaysBetweenDates', ->
     it 'will not find a holiday between dates that do not have a holiday between them', ->

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -154,7 +154,7 @@ describe 'app.CardRecorder', ->
   describe '.hasMovedCheck(actionList)', ->
     it 'will return true if a card has a list of acitons that has not moved', ->
       hasMoved = CR.hasMovedCheck(helpers.actionListMove)
-      expect(hasMoved).to.be.true
+      expect(hasMoved).to.eql [helpers.actionListMove[1]]
       return
 
     it 'will return false if a card has a list of acitons that has not moved', ->

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -210,7 +210,7 @@ describe 'app.CardRecorder', ->
   describe 'findLastMoveDateFromComments(opts)', ->
     it 'will return the date if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
       lastMove = CR.findLastMoveDateFromComments({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
-      expect(lastMove).to.eql '2016-03-21T00:00:00-04:00'
+      expect(lastMove).to.eql '2016-03-21T04:00:00.000Z'
       return
 
     it 'will return the last Action date is there is actionList and there is no date in the commentcard', ->
@@ -231,7 +231,7 @@ describe 'app.CardRecorder', ->
       comments = helpers.mockCommentCardObj.actions
       comments[0].data.text = "This comment has no date."
       lastMove = CR.findLastMoveDateFromComments({})
-      expect(lastMove).to.eql '2016-01-01T00:00:00-05:00'
+      expect(lastMove).to.eql '2016-01-01T05:00:00.000Z'
       return
     return
 

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -203,6 +203,19 @@ describe 'app.CardRecorder', ->
       return
     return
 
+  describe 'findLastMoveDateFromComments(commentList)', ->
+    it 'will return the date if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
+      lastMove = CR.findLastMoveDateFromComments(helpers.mockCommentCardObj.actions)
+      expect(lastMove).to.eql '03/21/2016'
+      return
+
+    it 'will return false if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
+      comments = helpers.mockCommentCardObj.actions
+      comments[0].data.text = "This comment has no date."
+      lastMove = CR.findLastMoveDateFromComments(comments)
+      expect(lastMove).to.eql false
+      return
+    return
   describe '.findHolidaysBetweenDates', ->
     it 'will not find a holiday between dates that do not have a holiday between them', ->
       holidays = CR.findHolidaysBetweenDates('01-04-2016', '01-10-2016')

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -5,6 +5,7 @@ helpers = require('./test-helpers.js')
 q = require('q')
 trello = require('node-trello')
 sinon = require('sinon');
+moment = require('moment')
 require('sinon-as-promised');
 
 # sinon.stub::asyncOutcome = (args, asyncResp) ->
@@ -209,8 +210,9 @@ describe 'app.CardRecorder', ->
 
   describe 'findLastMoveDateFromComments(opts)', ->
     it 'will return the date if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
+      localMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
       lastMove = CR.findLastMoveDateFromComments({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
-      expect(lastMove).to.eql '2016-03-21T04:00:00.000Z'
+      expect(lastMove).to.eql localMoment
       return
 
     it 'will return the last Action date is there is actionList and there is no date in the commentcard', ->
@@ -230,8 +232,9 @@ describe 'app.CardRecorder', ->
     it 'will return "01/01/2016 if there is nothing in the options', ->
       comments = helpers.mockCommentCardObj.actions
       comments[0].data.text = "This comment has no date."
+      localMoment = moment("2016-01-01").toISOString()
       lastMove = CR.findLastMoveDateFromComments({})
-      expect(lastMove).to.eql '2016-01-01T05:00:00.000Z'
+      expect(lastMove).to.eql localMoment
       return
     return
 

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -22,13 +22,15 @@ describe 'app.CardRecorder', ->
     compileStub = undefined
     getCards = undefined
     lastListStub = undefined
+    findLastStub = undefined
 
     beforeEach ->
       sandbox = sinon.sandbox.create()
       deleteCards = sandbox.stub(CR, 'deleteCurrentComment').resolves({"currentCommentDeleted": true});
       sandbox.stub(CR, 'getListNameByID').resolves('list name');
       lastListStub = sandbox.stub(CR, 'getLastList')
-      compileStub = sandbox.stub(CR, 'compileCommentArtifact').yieldsAsync();
+      findLastStub = sandbox.stub(CR, 'findLastMoveDateFromComments').returns("01/12/2016");
+      compileStub = sandbox.stub(CR, 'compileCommentArtifact').resolves("Compiled Comment");
       return
 
     afterEach ->
@@ -38,28 +40,26 @@ describe 'app.CardRecorder', ->
     it 'will run the cardRecorder class for a list that has moved', (done) ->
       # Set the action date to less than a day ago
       # to trigger the phase change
-      cardActions = helpers.actionListMove
-      cardActions.concat(helpers.mockCommentCardObj.actions)
+      cardActions = helpers.actionListMove.concat(helpers.mockCommentCardObj.actions)
       cardActions.forEach (action) ->
         action.date = (new Date(Date.now() - 21600000)).toISOString();
         return
 
-      getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', actions: cardActions}])
-      CR.run().then ->
+      getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', name: 'BPA Project - Phase II', actions: cardActions}])
+      CR.run().then (resp) ->
         expect(getCards.callCount).to.equal 1
-        # expect(deleteCards.callCount).to.equal 1
-        # expect(compileStub.callCount).to.equal 1
+        expect(deleteCards.callCount).to.equal 1
+        expect(compileStub.callCount).to.equal 1
         done()
         return
       return
 
     it 'will run the cardRecorder class for a list that has not moved', (done) ->
-      cardActions = helpers.actionListNoMove
-      cardActions.concat(helpers.mockCommentCardObj.actions)
-      getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', actions: cardActions}])
-      CR.run().then ->
-        # expect(deleteCards.callCount).to.equal 1
-        # expect(compileStub.callCount).to.equal 1
+      cardActions = helpers.actionListNoMove.concat(helpers.mockCommentCardObj.actions)
+      getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', name: 'BPA Project - Phase II', actions: cardActions}])
+      CR.run().then (resp) ->
+        expect(deleteCards.callCount).to.equal 1
+        expect(compileStub.callCount).to.equal 1
         done()
         return
       return

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -213,5 +213,163 @@ testCard: { id: 'xxxxx',
   pos: 16384,
   shortUrl: 'https://trello.com/c/xddwxws',
   url: 'https://trello.com/c/xddwxws/34-bpa-project-phase-ii',
-  stickers: [] }
+  stickers: []
+},
+  mockCommentCardObj: {
+    id: "0",
+    badges: {
+      votes: 0,
+      viewingMemberVoted: false,
+      subscribed: true,
+      fogbugz: "",
+      checkItems: 0,
+      checkItemsChecked: 0,
+      comments: 4,
+      attachments: 0,
+      description: true,
+      due: null
+    },
+    checkItemStates: [ ],
+    closed: false,
+    dateLastActivity: "2016-04-19T22:53:02.061Z",
+    desc: "Comment Card Obj ",
+    descData: {
+      emoji: { }
+      },
+    due: null,
+    email: "cool@boards.trello.com",
+    idBoard: "ccc",
+    idChecklists: [ ],
+    idList: "111",
+    idMembers: [
+      "ddd",
+      "ddd3",
+      "efss"
+      ],
+    idMembersVoted: [ ],
+    idShort: 1,
+    idAttachmentCover: null,
+    manualCoverAttachment: false,
+    labels: [ ],
+    idLabels: [ ],
+    name: "Comment Mock Card",
+    pos: 1,
+    shortLink: "9322",
+    shortUrl: "https://trello.com/c/9322",
+    subscribed: true,
+    url: "https://trello.com/c/9322/comment-mock-card",
+    checklists: [ ],
+    members: [
+      {
+      id: "dddd",
+      avatarHash: "dke",
+      bio: "",
+      bioData: null,
+      confirmed: true,
+      fullName: "Bob Tester",
+      idPremOrgsAdmin: [ ],
+      initials: "BT",
+      memberType: "normal",
+      products: [ ],
+      status: "disconnected",
+      url: "https://trello.com/bobtester",
+      username: "bobtester"
+      },
+      {
+      id: "dddd",
+      avatarHash: "dke",
+      bio: "",
+      bioData: null,
+      confirmed: true,
+      fullName: "Bob Tester",
+      idPremOrgsAdmin: [ ],
+      initials: "BT",
+      memberType: "normal",
+      products: [ ],
+      status: "disconnected",
+      url: "https://trello.com/bobtester",
+      username: "bobtester"
+      },
+      {
+      id: "dddd",
+      avatarHash: "dke",
+      bio: "",
+      bioData: null,
+      confirmed: true,
+      fullName: "Bob Tester",
+      idPremOrgsAdmin: [ ],
+      initials: "BT",
+      memberType: "normal",
+      products: [ ],
+      status: "disconnected",
+      url: "https://trello.com/bobtester",
+      username: "bobtester"
+      }
+    ],
+    actions: [
+      {
+      id: "2",
+      idMemberCreator: "ddd",
+      data: {
+      list: {
+      name: "Test List",
+      id: "testlistID"
+      },
+      board: {
+        shortLink: "333",
+        name: "Test Board",
+        id: "testboardID"
+        },
+      card: {
+        shortLink: "sss",
+        idShort: 1,
+        name: "Comment Test Card",
+        id: "322"
+        },
+      text: "**Current Stage:** `+19 days`. *03/21/2016 - 03/08/2016*. Expected days: 2 days. Actual Days spent: 21."
+      },
+      type: "commentCard",
+      date: "2016-03-08T22:53:02.063Z",
+      memberCreator: {
+        id: "asdf9",
+        avatarHash: "adafa",
+        fullName: "Bob Tester",
+        initials: "BT",
+        username: "bobtester"
+        }
+      },
+      {
+        id: "4",
+        idMemberCreator: "ddd",
+        data: {
+        list: {
+        name: "Test List",
+        id: "testlistID"
+        },
+        board: {
+        shortLink: "333",
+        name: "Test Board",
+        id: "testboardID"
+        },
+        card: {
+        shortLink: "0",
+        idShort: 1,
+        name: "Comment Test Card",
+        id: "322"
+        },
+        text: "This is not a current comment."
+        },
+        type: "commentCard",
+        date: "2016-03-08T22:53:02.063Z",
+        memberCreator: {
+        id: "asdf9",
+        avatarHash: "adafa",
+        fullName: "Bob Tester",
+        initials: "BT",
+        username: "bobtester"
+        }
+      }
+
+    ]
+    }
 }

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -342,22 +342,22 @@ testCard: { id: 'xxxxx',
         id: "4",
         idMemberCreator: "ddd",
         data: {
-        list: {
-        name: "Test List",
-        id: "testlistID"
-        },
-        board: {
-        shortLink: "333",
-        name: "Test Board",
-        id: "testboardID"
-        },
-        card: {
-        shortLink: "0",
-        idShort: 1,
-        name: "Comment Test Card",
-        id: "322"
-        },
-        text: "This is not a current comment."
+          list: {
+          name: "Test List",
+          id: "testlistID"
+          },
+          board: {
+          shortLink: "333",
+          name: "Test Board",
+          id: "testboardID"
+          },
+          card: {
+          shortLink: "0",
+          idShort: 1,
+          name: "Comment Test Card",
+          id: "322"
+          },
+          text: "This is not a current comment."
         },
         type: "commentCard",
         date: "2016-03-08T22:53:02.063Z",


### PR DESCRIPTION
Add the first portion of the "lazy" card recorder that uses the previous comment's start date (if it exists) to populate the from date of the cardRecorder. Updated tests as well. Closes #45.