### PR TITLE
Add total days to Card Recorder Comment

### DIFF
--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -122,9 +122,7 @@ class CardRecorder extends MyTrello {
       if(correctComment){
         var commentDateMatch = myRegex.exec(correctComment.data.text);
         var commentDate = commentDateMatch[1];
-        console.log(commentDate);
-        var commMoment = String(moment(commentDate, "MM/DD/YYYY").toISOString());
-        console.log(commMoment);
+        var commMoment = moment(commentDate, "MM/DD/YYYY").toISOString();
         return commMoment;
       } else {
         return false;
@@ -198,8 +196,6 @@ class CardRecorder extends MyTrello {
 
     findHolidaysBetweenDates(fromDate, toDate){
       var count = 0;
-      //var fromD = moment(fromDate, "YYYY-MM-DD");
-      // var toD = moment(toDate , "YYYY-MM-DD");
       _un.each(holidays, function(holiday){
         if(moment(holiday.date.toISOString(), ["YYYY-M-D", "YYYY-MM-DD", "YYYY-MM-D", "YYYY-M-DD"]).isBetween(fromDate, toDate, 'day')){
           count++;
@@ -212,7 +208,6 @@ class CardRecorder extends MyTrello {
         var fromDate = new Date(lastMove);
         var toDate = new Date(recentMove);
         var diffDays = instadate.differenceInWorkDays(fromDate, toDate);
-        console.log(diffDays);
         var diffDays = diffDays - this.findHolidaysBetweenDates(fromDate, toDate);
         return [diffDays - expected, diffDays];
     }

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -28,13 +28,14 @@ class CardRecorder extends MyTrello {
                 self.deleteCurrentComment(comments).then(function(resp) {
                     var updateActions = _.filter(card.actions, {type: "updateCard"});
                     var createAction = _.filter(card.actions, {type: "createCard"});
+                    var now = moment();
                     var hasMoved = false;
+                    var daysSinceUpdate = false;
                     if(typeof updateActions !== "undefined"){
                       hasMoved = self.hasMovedCheck(updateActions);
+                      daysSinceUpdate = now.diff(moment(updateActions[0].date), 'days');
                     }
                     var lastMove = self.findLastMoveDateFromComments({commentList: comments, "actionList": updateActions, "createActionDate": createAction.date});
-                    var now = moment();
-                    var daysSinceUpdate = now.diff(lastMove, 'days');
                     if (hasMoved && daysSinceUpdate < 1) {
                         console.log("Write New Phase: " + card.name);
                         var lastPhase = self.getLastList(hasMoved[0]);
@@ -42,8 +43,8 @@ class CardRecorder extends MyTrello {
                             card.id,
                             lastPhase,
                             lastPhase,
-                            updateActions[1].date,
                             lastMove,
+                            updateActions[0].date,
                             true
                         )
                         .then(deferred.resolve);

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -166,9 +166,9 @@ class CardRecorder extends MyTrello {
     }
 
     calcTotalDays(commentList, nowMoment){
-        var firstDate = this.checkComments(commentList, false);
+        var firstDate = this.checkCommentsForDates(commentList, false);
         if(firstDate){
-          dayDif = this.calculateDateDifference(10, firstDate, nowMoment)
+          var dayDif = this.calculateDateDifference(10, firstDate, nowMoment)
           //expected not actually needed, in the future could say total days expected
           return dayDif[1];
         } else {

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -116,9 +116,8 @@ class CardRecorder extends MyTrello {
       }
       var correctComment = _.find(commentList, function(comment){
           var match = myRegex.exec(comment.data.text);
-          return match ? match[1] : false;
+          return match ? true : false;
       });
-      // console.log(correctComment);
       if(correctComment){
         var commentDateMatch = myRegex.exec(correctComment.data.text);
         var commentDate = commentDateMatch[1];

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -16,7 +16,7 @@ CR = new app.CardRecorder(helpers.mockfile, helpers.board)
 # CR.Stages = helpers.expectedStageObject
 
 describe 'app.CardRecorder', ->
-  describe '.run', ->
+  describe.skip '.run', ->
     sandbox = undefined
     deleteCards = undefined
     listStub = undefined
@@ -177,6 +177,11 @@ describe 'app.CardRecorder', ->
       return
     return
 
+  describe '.calcTotalDays(commentList, nowMoment)', ->
+    it 'calculates takes a comment list and finds the oldest date and then calculates the total number of days', ->
+      return
+    return
+
   describe '.compileCommentArtifact(cardID, dateList, nameList, fromDate, toDate, addCommentOpt)', ->
     sandbox = undefined
     addComment = undefined
@@ -191,24 +196,59 @@ describe 'app.CardRecorder', ->
       return
 
     it 'will run the date diff functions, build and post a comment', (done) ->
-      commentPromise = CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', true)
+      commentPromise = CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', true, 0)
       commentPromise.done (resp) ->
-        expect(addComment.calledWith('**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.')).to.be.ok
+        expect(addComment.calledWith('**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113. **Total Project Days: 0**')).to.be.ok
         expect(addComment.callCount).to.equal 1
         done()
         return
       return
 
     it 'will run the date diff functions, but not actually create a comment', (done) ->
-      CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', false).then (comment) ->
-        expect(comment).to.eql '**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.'
+      CR.compileCommentArtifact('xxxx', 'Workshop Prep', 'Workshop Prep', '2016-04-05T10:40:26.100Z', '2016-07-27T10:40:26.100Z', false, 0).then (comment) ->
+        expect(comment).to.eql '**Workshop Prep Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113. **Total Project Days: 0**'
         expect(addComment.callCount).to.equal 0
         done()
         return
       return
     return
 
+  describe 'checkCommentsForDates(commentList, latest)', ->
+    afterEach ->
+      localMoment = null
+      return
+
+    it 'will check if a comment has a date and return the lastest date from a comment list', ->
+      lastMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
+      lastMove = CR.findLastMoveDateFromComments(helpers.mockCommentCardObj.actions, true)
+      expect(lastMove).to.eql lastMoment
+      return
+
+    # it 'will check if a comment has a date and return the first date from a comment list', ->
+    #   localMoment = moment("2016-01-02").toISOString(); #to get out of localization of test suite
+    #   commentList = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions)) #clone to modify
+    #   oldComment =
+    #     id: '2'
+    #     data: text: '**IAA Stage:** `+19 days`. *01/02/2016 - 03/08/2016*. Expected days: 2 days. Actual Days spent: 21.'
+    #   commentList.push oldComment
+    #   lastMove = CR.findLastMoveDateFromComments(commentList, false)
+    #   expect(lastMove).to.eql localMoment
+    #   return
+    #
+    # it 'will return false when there is no comment that matches the date string', ->
+    #   comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
+    #   comments[0].data.text = "This comment has no date."
+    #   lastMove = CR.findLastMoveDateFromComments(comments, true)
+    #   expect(lastMove).to.be.false
+    #   return
+    return
+
   describe 'findLastMoveDateFromComments(opts)', ->
+
+    afterEach ->
+      localMoment = null
+      return
+
     it 'will return the date if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
       localMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
       lastMove = CR.findLastMoveDateFromComments({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
@@ -216,36 +256,36 @@ describe 'app.CardRecorder', ->
       return
 
     it 'will return the last Action date is there is actionList and there is no date in the commentcard', ->
-      comments = helpers.mockCommentCardObj.actions
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
       comments[0].data.text = "This comment has no date."
       lastMove = CR.findLastMoveDateFromComments({"commentList": comments, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
       expect(lastMove).to.eql '2016-02-25T22:00:35.866Z'
       return
 
     it 'will return the creation date if there is no actionList or no current comment', ->
-      comments = helpers.mockCommentCardObj.actions
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
       comments[0].data.text = "This comment has no date."
       lastMove = CR.findLastMoveDateFromComments({"commentList": comments, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
       expect(lastMove).to.eql '2016-04-05T10:40:26.100Z'
       return
 
-    it 'will return "01/01/2016 if there is nothing in the options', ->
-      comments = helpers.mockCommentCardObj.actions
-      comments[0].data.text = "This comment has no date."
-      localMoment = moment("2016-01-01").toISOString()
-      lastMove = CR.findLastMoveDateFromComments({})
-      expect(lastMove).to.eql localMoment
-      return
-    return
+    # it 'will return "01/01/2016 if there is nothing in the options', ->
+    #   comments = helpers.mockCommentCardObj.actions
+    #   comments[0].data.text = "This comment has no date."
+    #   localMoment = moment("2016-01-02").toISOString()
+    #   lastMove = CR.findLastMoveDateFromComments({})
+    #   expect(lastMove).to.eql localMoment
+    #   return
+    # return
 
   describe '.findHolidaysBetweenDates', ->
     it 'will not find a holiday between dates that do not have a holiday between them', ->
-      holidays = CR.findHolidaysBetweenDates('01-04-2016', '01-10-2016')
+      holidays = CR.findHolidaysBetweenDates(new Date('01-04-2016'), new Date('01-10-2016'))
       expect(holidays).to.eql 0
       return
 
     it 'will find that there are two holidays between 4/5/16 and 7/27/16', ->
-      holidays = CR.findHolidaysBetweenDates("2016-04-05", "2016-07-27")
+      holidays = CR.findHolidaysBetweenDates(new Date('2016-04-05'), new Date('2016-07-27'))
       expect(holidays).to.eql 2
       return
 
@@ -260,8 +300,8 @@ describe 'app.CardRecorder', ->
 
   describe '.buildComment', ->
     it 'generates a comment Based off of date entry fields', ->
-      msg = CR.buildComment(103, 10, "2016-04-05T10:40:26.100Z", "2016-07-27T10:40:26.100Z", "Workshop", 113)
-      expect(msg).to.eql("**Workshop Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113.")
+      msg = CR.buildComment(103, 10, "2016-04-05T10:40:26.100Z", "2016-07-27T10:40:26.100Z", "Workshop", 113, 0)
+      expect(msg).to.eql("**Workshop Stage:** `+103 days`. *04/05/2016 - 07/27/2016*.\n Expected days: 10 days. Actual Days spent: 113. **Total Project Days: 0**")
       return
     return
 

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -264,10 +264,6 @@ describe 'app.CardRecorder', ->
 
   describe 'findLastMoveDateFromComments(opts)', ->
 
-    afterEach ->
-      localMoment = null
-      return
-
     it 'will return the date if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
       localMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
       lastMove = CR.findLastMoveDateFromComments({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
@@ -288,14 +284,14 @@ describe 'app.CardRecorder', ->
       expect(lastMove).to.eql '2016-04-05T10:40:26.100Z'
       return
 
-    # it 'will return "01/01/2016 if there is nothing in the options', ->
-    #   comments = helpers.mockCommentCardObj.actions
-    #   comments[0].data.text = "This comment has no date."
-    #   localMoment = moment("2016-01-02").toISOString()
-    #   lastMove = CR.findLastMoveDateFromComments({})
-    #   expect(lastMove).to.eql localMoment
-    #   return
-    # return
+    it 'will return "01/01/2016 if there is nothing in the options', ->
+      comments = helpers.mockCommentCardObj.actions
+      comments[0].data.text = "This comment has no date."
+      localMoment = moment("2016-01-01").toISOString()
+      lastMove = CR.findLastMoveDateFromComments({})
+      expect(lastMove).to.eql localMoment
+      return
+    return
 
   describe '.findHolidaysBetweenDates', ->
     it 'will not find a holiday between dates that do not have a holiday between them', ->

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -214,33 +214,36 @@ describe 'app.CardRecorder', ->
     return
 
   describe 'checkCommentsForDates(commentList, latest)', ->
+    beforeEach ->
+      localMoment = undefined
+      return
     afterEach ->
       localMoment = null
       return
 
     it 'will check if a comment has a date and return the lastest date from a comment list', ->
       lastMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
-      lastMove = CR.findLastMoveDateFromComments(helpers.mockCommentCardObj.actions, true)
+      lastMove = CR.checkCommentsForDates(helpers.mockCommentCardObj.actions, true)
       expect(lastMove).to.eql lastMoment
       return
 
-    # it 'will check if a comment has a date and return the first date from a comment list', ->
-    #   localMoment = moment("2016-01-02").toISOString(); #to get out of localization of test suite
-    #   commentList = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions)) #clone to modify
-    #   oldComment =
-    #     id: '2'
-    #     data: text: '**IAA Stage:** `+19 days`. *01/02/2016 - 03/08/2016*. Expected days: 2 days. Actual Days spent: 21.'
-    #   commentList.push oldComment
-    #   lastMove = CR.findLastMoveDateFromComments(commentList, false)
-    #   expect(lastMove).to.eql localMoment
-    #   return
-    #
-    # it 'will return false when there is no comment that matches the date string', ->
-    #   comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
-    #   comments[0].data.text = "This comment has no date."
-    #   lastMove = CR.findLastMoveDateFromComments(comments, true)
-    #   expect(lastMove).to.be.false
-    #   return
+    it 'will check if a comment has a date and return the first date from a comment list', ->
+      localMoment = moment("2016-01-02").toISOString(); #to get out of localization of test suite
+      commentList = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions)) #clone to modify
+      oldComment =
+        id: '2'
+        data: text: '**IAA Stage:** `+19 days`. *01/02/2016 - 03/08/2016*. Expected days: 2 days. Actual Days spent: 21.'
+      commentList.push oldComment
+      lastMove = CR.checkCommentsForDates(commentList, false)
+      expect(lastMove).to.eql localMoment
+      return
+
+    it 'will return false when there is no comment that matches the date string', ->
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
+      comments[0].data.text = "This comment has no date."
+      lastMove = CR.checkCommentsForDates(comments, true)
+      expect(lastMove).to.be.false
+      return
     return
 
   describe 'findLastMoveDateFromComments(opts)', ->

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -188,7 +188,6 @@ describe 'app.CardRecorder', ->
       totalDays = CR.calcTotalDays(comments, fakeNow)
       expect(totalDays).to.eql 195
       return
-    return
 
     it 'will return 0 if the comment list does not have and "MM/DD/YYYY - MM/DD/YYYY" regular expressions in the text', ->
       comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -16,7 +16,7 @@ CR = new app.CardRecorder(helpers.mockfile, helpers.board)
 # CR.Stages = helpers.expectedStageObject
 
 describe 'app.CardRecorder', ->
-  describe.skip '.run', ->
+  describe '.run', ->
     sandbox = undefined
     deleteCards = undefined
     listStub = undefined
@@ -178,7 +178,24 @@ describe 'app.CardRecorder', ->
     return
 
   describe '.calcTotalDays(commentList, nowMoment)', ->
-    it 'calculates takes a comment list and finds the oldest date and then calculates the total number of days', ->
+    it 'calculates takes a comment list and finds the oldest date and then calculates the total number of business days', ->
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions)) #clone to modify
+      oldComment =
+        id: '2'
+        data: text: '**IAA Stage:** `+19 days`. *01/02/2016 - 03/08/2016*. Expected days: 2 days. Actual Days spent: 21.'
+      comments.push oldComment
+      fakeNow = moment("2016-10-10")
+      totalDays = CR.calcTotalDays(comments, fakeNow)
+      expect(totalDays).to.eql 195
+      return
+    return
+
+    it 'will return 0 if the comment list does not have and "MM/DD/YYYY - MM/DD/YYYY" regular expressions in the text', ->
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
+      comments[0].data.text = "This comment has no date."
+      fakeNow = moment("2016-10-10")
+      totalDays = CR.calcTotalDays(comments, fakeNow)
+      expect(totalDays).to.eql 0
       return
     return
 

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -312,8 +312,8 @@ testCard: { id: 'xxxxx',
       idMemberCreator: "ddd",
       data: {
       list: {
-      name: "Test List",
-      id: "testlistID"
+        name: "Test List",
+        id: "testlistID"
       },
       board: {
         shortLink: "333",


### PR DESCRIPTION
Close #46.

Adds tests/functions to calculate the total project business days (from the oldest comment with a date in the text of the comment)

[Also addresses date objects throwing `warning` in the holiday function.]