### PR TITLE
make a shallow copy of commentList for reverse to not break integration

### DIFF
--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -116,8 +116,8 @@ class CardRecorder extends MyTrello {
     checkCommentsForDates(commentList, latest){
       var myRegex = /(\d\d\/\d\d\/201\d) - \d\d\/\d\d\/201\d/; //Find the first date in the comment string
       if(!latest){
-        // Reverse order to get first comment
-        commentList = commentList.reverse();
+        // Reverse order to get first comment but create a shallow copy to not break integration
+        commentList = commentList.slice(0).reverse();
       }
       var correctComment = commentList.find(function(comment){
           var match = myRegex.exec(comment.data.text);


### PR DESCRIPTION
An attempt to fix #57 by making a shallow copy of the comment object that gets passed through `CardRecorder.checkCommentsForDates()` so that it will find the correct comment in the `CardRecorder.run()` method.