### PR TITLE
Major refactor to break out .run method and create new helper class

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+exclude_paths:
+  cli.js

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -61,9 +61,10 @@ class CardRecorder extends MyTrello {
               cardActions.updates,
               totDays,
               now)
-            .then(function(resp){
-              deferred.resolve(resp);});
-          });
+            .then(function(resp){deferred.resolve(resp);});
+          })
+          .catch(function(err){console.log(err.stack);
+          deferred.reject(err);});
       });
     return deferred.promise;
     }

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -63,8 +63,8 @@ class CardRecorder extends MyTrello {
               now)
             .then(function(resp){deferred.resolve(resp);});
           })
-          .catch(function(err){console.log(err.stack);
-          deferred.reject(err);});
+          // .catch(function(err){console.log(err.stack);
+          // deferred.reject(err);});
       });
     return deferred.promise;
     }

--- a/app/date-comment-helpers.js
+++ b/app/date-comment-helpers.js
@@ -42,7 +42,7 @@ class DateCommentHelpers {
     var commentList = opts.commentList;
     var correctComment = false;
     if(commentList){
-      var correctComment = this.checkCommentsForDates(commentList, true);
+      correctComment = this.checkCommentsForDates(commentList, true);
     }
     if(correctComment){
       return correctComment;
@@ -74,7 +74,7 @@ class DateCommentHelpers {
       var fromDate = new Date(prevMove);
       var toDate = new Date(recentMove);
       var diffDays = instadate.differenceInWorkDays(fromDate, toDate);
-      var diffDays = diffDays - this.findHolidaysBetweenDates(fromDate, toDate);
+      diffDays = diffDays - this.findHolidaysBetweenDates(fromDate, toDate);
       return [diffDays - expected, diffDays];
   }
 

--- a/app/date-comment-helpers.js
+++ b/app/date-comment-helpers.js
@@ -1,0 +1,92 @@
+"use strict";
+
+var instadate = require("instadate");
+var moment = require("moment");
+var fedHolidays = require('@18f/us-federal-holidays');
+var d = new Date();
+var holidays = fedHolidays.allForYear(d.getFullYear());
+
+class DateCommentHelpers {
+  hasMovedCheck(actionList) {
+      var updated = false;
+      var moves = actionList.filter(function(a) {
+          return 'listBefore' in a.data;
+      });
+      if (moves.length) updated = moves;
+      return updated;
+  }
+
+  checkCommentsForDates(commentList, latest){
+    var myRegex = /(\d\d\/\d\d\/201\d) - \d\d\/\d\d\/201\d/; //Find the first date in the comment string
+    if(!latest){
+      // Reverse order to get first comment but create a shallow copy to not break integration
+      commentList = commentList.slice(0).reverse();
+    }
+    var correctComment = commentList.find(function(comment){
+        var match = myRegex.exec(comment.data.text);
+        return match ? true : false;
+    });
+    if(correctComment){
+      var commentDateMatch = myRegex.exec(correctComment.data.text);
+      var commentDate = commentDateMatch[1];
+      var commMoment = moment(commentDate, "MM/DD/YYYY").toISOString();
+      return commMoment;
+    } else {
+      return false;
+    }
+  }
+
+  findPrevMoveDateFromComments(opts){
+    var actionList = opts.actionList;
+    var cardCreationDate = opts.cardCreationDate;
+    var commentList = opts.commentList;
+    var correctComment = false;
+    if(commentList){
+      var correctComment = this.checkCommentsForDates(commentList, true);
+    }
+    if(correctComment){
+      return correctComment;
+    } else if(actionList) {
+      if(actionList.length > 1){
+      return actionList[0].date;
+      }
+    } else {
+      if(opts.cardCreationDate){
+        return cardCreationDate;
+      } else {
+        return moment("01/01/2016", "MM/DD/YYYY").toISOString();
+      }
+    }
+  }
+
+  calcTotalDays(commentList, nowMoment){
+      var firstDate = this.checkCommentsForDates(commentList, false);
+      if(firstDate){
+        var dayDif = this.calculateDateDifference(10, firstDate, nowMoment)
+        //expected not actually needed, in the future could say total days expected
+        return dayDif[1];
+      } else {
+        return 0;
+      }
+  }
+
+  calculateDateDifference(expected, prevMove, recentMove) {
+      var fromDate = new Date(prevMove);
+      var toDate = new Date(recentMove);
+      var diffDays = instadate.differenceInWorkDays(fromDate, toDate);
+      var diffDays = diffDays - this.findHolidaysBetweenDates(fromDate, toDate);
+      return [diffDays - expected, diffDays];
+  }
+
+  findHolidaysBetweenDates(fromDate, toDate){
+    var count = 0;
+    holidays.forEach(function(holiday){
+      if(moment(holiday.date.toISOString(), ["YYYY-M-D", "YYYY-MM-DD", "YYYY-MM-D", "YYYY-M-DD"]).isBetween(fromDate, toDate, 'day')){
+        count++;
+      }
+    });
+    return count;
+  }
+}
+
+module.exports = DateCommentHelpers;

--- a/app/index.js
+++ b/app/index.js
@@ -3,3 +3,4 @@ require("dotenv").config();
 exports.StageManager = require("./stagemanager.js");
 exports.CardRecorder = require("./cardrecord.js");
 exports.CardCreator = require("./cardcreator.js");
+exports.DateCommentHelpers = require("./date-comment-helpers.js");

--- a/cli.js
+++ b/cli.js
@@ -13,23 +13,23 @@ if ("i" in argv){
 
 if ("s" in argv){
   console.log("--Invoke Stage Manager--");
-  var file  = (argv["s"]=== true) ? 'data/stages.yaml' : argv["s"];
-  var SM = new app.StageManager(file, board);
+  var smFile  = (argv["s"]=== true) ? 'data/stages.yaml' : argv["s"];
+  var SM = new app.StageManager(smFile, board);
   SM.run().then(function(resp){console.log("Stage Manager Complete")});
 }
 
 if ("r" in argv) {
   console.log("--Invoke Card Recorder--");
-  var file  = (argv["r"]=== true) ? 'data/stages.yaml' : argv["r"];
-  var CR = new app.CardRecorder(file, board);
+  var crFile  = (argv["r"]=== true) ? 'data/stages.yaml' : argv["r"];
+  var CR = new app.CardRecorder(crFile, board);
   CR.run().then(function(resp){console.log("--Card Recorder Complete--")});
 }
 
 if ("c" in argv) {
   console.log("--Invoke Card Creator--");
-  var file  = (argv["c"]=== true) ? 'data/stages.yaml' : argv["c"];
+  var ccFile  = (argv["c"]=== true) ? 'data/stages.yaml' : argv["c"];
   var orders  = (argv["o"]=== true) ? 'data/orders.yaml' : argv["o"];
-  var CC = new app.CardCreator(file, board);
+  var CC = new app.CardCreator(ccFile, board);
   CC.createOrders(orders).then(function(resp){
     console.log("--Card Creator Complete--");});
 }
@@ -37,7 +37,7 @@ if ("c" in argv) {
 if ("b" in argv) {
   //Args = Name of list > -d ,fromDate > -f, toDate > -t
   console.log("--Build a Comment--");
-  var file  = (argv["b"]=== true) ? 'data/stages.yaml' : argv["d"];
-  var CR = new app.CardRecorder(file, board);
-  CR.compileCommentArtifact(null, argv.d, argv.d, argv.f, argv.t, false).then(function(comment){console.log(comment)});
+  var crCLIFile  = (argv["b"]=== true) ? 'data/stages.yaml' : argv["d"];
+  var BuildCR = new app.CardRecorder(crCLIFile, board);
+  BuildCR.compileCommentArtifact(null, argv.d, argv.d, argv.f, argv.t, false).then(function(comment){console.log(comment)});
 }

--- a/cli.js
+++ b/cli.js
@@ -10,34 +10,39 @@ if ("i" in argv){
   board = process.env.TRELLO_BOARD_ID;
 }
 
+//Run the CardRecorder class to add date driven comments to trello cards
+addCommandPrompt("r", "CardRecorder", function(file, tN){
+    var CR = new app.CardRecorder(file, board);
+    CR.run().then(function(resp){console.log("--"+tN+" Complete--")});
+});
 
-if ("s" in argv){
-  console.log("--Invoke Stage Manager--");
-  var smFile  = (argv["s"]=== true) ? 'data/stages.yaml' : argv["s"];
-  var SM = new app.StageManager(smFile, board);
-  SM.run().then(function(resp){console.log("Stage Manager Complete")});
-}
+//Run the Stage Manager class to add lists to a board
+addCommandPrompt("s", "Stage Manager", function(file, tN){
+  var SM = new app.StageManager(file, board);
+  SM.run().then(function(resp){console.log("--"+tN+" Complete--")});
+});
 
-if ("r" in argv) {
-  console.log("--Invoke Card Recorder--");
-  var crFile  = (argv["r"]=== true) ? 'data/stages.yaml' : argv["r"];
-  var CR = new app.CardRecorder(crFile, board);
-  CR.run().then(function(resp){console.log("--Card Recorder Complete--")});
-}
-
-if ("c" in argv) {
-  console.log("--Invoke Card Creator--");
-  var ccFile  = (argv["c"]=== true) ? 'data/stages.yaml' : argv["c"];
+//Run the Card Creator class to add cards to a board from a file
+addCommandPrompt("c", "Card Creator", function(file, tN){
   var orders  = (argv["o"]=== true) ? 'data/orders.yaml' : argv["o"];
-  var CC = new app.CardCreator(ccFile, board);
+  var CC = new app.CardCreator(file, board);
   CC.createOrders(orders).then(function(resp){
-    console.log("--Card Creator Complete--");});
-}
+    console.log("--"+tN+" Complete--");});
+});
 
+//Print out a comment to the command line
 if ("b" in argv) {
   //Args = Name of list > -d ,fromDate > -f, toDate > -t
   console.log("--Build a Comment--");
-  var crCLIFile  = (argv["b"]=== true) ? 'data/stages.yaml' : argv["d"];
+  var crCLIFile  = (argv["b"]=== true) ? 'data/stages.yaml' : argv["b"];
   var BuildCR = new app.CardRecorder(crCLIFile, board);
   BuildCR.compileCommentArtifact(null, argv.d, argv.d, argv.f, argv.t, false).then(function(comment){console.log(comment)});
+}
+
+function addCommandPrompt(flag, taskName, callback){
+  if (flag in argv){
+    console.log("--Invoke "+taskName+"--");
+    var file = (argv[flag]=== true) ? 'data/stages.yaml' : argv[flag];
+    callback(file, arguments[1]);
+  }
 }

--- a/cli.js
+++ b/cli.js
@@ -15,14 +15,14 @@ if ("s" in argv){
   console.log("--Invoke Stage Manager--");
   var file  = (argv["s"]=== true) ? 'data/stages.yaml' : argv["s"];
   var SM = new app.StageManager(file, board);
-  SM.run().then(console.log("Stage Manager Complete"));
+  SM.run().then(function(resp){console.log("Stage Manager Complete")});
 }
 
 if ("r" in argv) {
   console.log("--Invoke Card Recorder--");
   var file  = (argv["r"]=== true) ? 'data/stages.yaml' : argv["r"];
   var CR = new app.CardRecorder(file, board);
-  CR.run().then(console.log("CR Complete"));
+  CR.run().then(function(resp){console.log("--Card Recorder Complete--")});
 }
 
 if ("c" in argv) {
@@ -30,7 +30,8 @@ if ("c" in argv) {
   var file  = (argv["c"]=== true) ? 'data/stages.yaml' : argv["c"];
   var orders  = (argv["o"]=== true) ? 'data/orders.yaml' : argv["o"];
   var CC = new app.CardCreator(file, board);
-  CC.createOrders(orders).then(console.log("--Card Creator Complete--"));
+  CC.createOrders(orders).then(function(resp){
+    console.log("--Card Creator Complete--");});
 }
 
 if ("b" in argv) {

--- a/cli.js
+++ b/cli.js
@@ -10,34 +10,50 @@ if ("i" in argv){
   board = process.env.TRELLO_BOARD_ID;
 }
 
-//Run the CardRecorder class to add date driven comments to trello cards
-addCommandPrompt("r", "CardRecorder", function(file, tN){
-    var CR = new app.CardRecorder(file, board);
-    CR.run().then(function(resp){console.log("--"+tN+" Complete--")});
-});
+var cliCommands = [
+  {//Run the CardRecorder class to add date driven comments to trello cards
+    "flag": "r",
+   "task": "CardRecorder",
+   "command": function(file, tN){
+                var CR = new app.CardRecorder(file, board);
+                CR.run()
+                  .then(function(resp){console.log("--"+tN+" Complete--")});
+              }
+  },
+  {//Run the Stage Manager class to add lists to a board
+    "flag": "s",
+   "task": "StageManager",
+   "command": function(file, tN){
+                var SM = new app.StageManager(file, board);
+                SM.run()
+                  .then(function(resp){console.log("--"+tN+" Complete--")});
+              }
+  },
+  {//Run the Card Creator class to add cards to a board from a file
+    "flag": "c",
+   "task": "Card Creator",
+   "command": function(file, tN){
+                var hasNoOrderFile = (typeof argv.o === "undefined");
+                var orders  = (argv.o === true || hasNoOrderFile) ? 'data/orders.yaml' : argv.o;
+                var CC = new app.CardCreator(file, board);
+                CC.createOrders(orders)
+                  .then(function(resp){console.log("--"+tN+" Complete--");});}
+    },
+    {//Print out a comment to the command line
+    //Required Flags: -l ListName, -d Iso string of from date, -t Isostring of to date, -o total days
+      "flag": "b",
+     "task": "Build Comment",
+     "command": function(file, tN){
+                  var BuildCR = new app.CardRecorder(file, board);
+                  BuildCR.compileCommentArtifact(null, argv.l, argv.d, argv.f, argv.t, false, argv.o)
+                  .then(function(comment){console.log(comment)});
+                }
+    }
+];
 
-//Run the Stage Manager class to add lists to a board
-addCommandPrompt("s", "Stage Manager", function(file, tN){
-  var SM = new app.StageManager(file, board);
-  SM.run().then(function(resp){console.log("--"+tN+" Complete--")});
+cliCommands.forEach(function(command){
+  addCommandPrompt(command.flag, command.task, command.command);
 });
-
-//Run the Card Creator class to add cards to a board from a file
-addCommandPrompt("c", "Card Creator", function(file, tN){
-  var orders  = (argv["o"]=== true) ? 'data/orders.yaml' : argv["o"];
-  var CC = new app.CardCreator(file, board);
-  CC.createOrders(orders).then(function(resp){
-    console.log("--"+tN+" Complete--");});
-});
-
-//Print out a comment to the command line
-if ("b" in argv) {
-  //Args = Name of list > -d ,fromDate > -f, toDate > -t
-  console.log("--Build a Comment--");
-  var crCLIFile  = (argv["b"]=== true) ? 'data/stages.yaml' : argv["b"];
-  var BuildCR = new app.CardRecorder(crCLIFile, board);
-  BuildCR.compileCommentArtifact(null, argv.d, argv.d, argv.f, argv.t, false).then(function(comment){console.log(comment)});
-}
 
 function addCommandPrompt(flag, taskName, callback){
   if (flag in argv){

--- a/data/stages.yaml
+++ b/data/stages.yaml
@@ -21,3 +21,5 @@ stages:
     expected_time: 1
   - name: "Post-Award Kick-off"
     expected_time: 5
+  - name: "Post-Award Management"
+    expected_time: 43

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -15,78 +15,97 @@ CR = new app.CardRecorder(helpers.mockfile, helpers.board)
 # CR.Stages = helpers.expectedStageObject
 
 describe 'app.CardRecorder', ->
+  sandbox = undefined
+  beforeEach ->
+    sandbox = sinon.sandbox.create()
+    return
+
+  afterEach ->
+    sandbox.restore()
+    return
+
   describe '.run', ->
-    sandbox = undefined
-    deleteCards = undefined
-    listStub = undefined
-    compileStub = undefined
-    getCards = undefined
-    lastListStub = undefined
-    findLastStub = undefined
+    getCardsStub = undefined
+    cardRecordStub = undefined
 
     beforeEach ->
-      sandbox = sinon.sandbox.create()
-      deleteCards = sandbox.stub(CR, 'deleteCurrentComment').resolves({"currentCommentDeleted": true});
-      sandbox.stub(CR, 'getListNameByID').resolves('list name');
-      lastListStub = sandbox.stub(CR, 'getLastList').returns("Last List")
-      compileStub = sandbox.stub(CR, 'compileCommentArtifact').resolves("Compiled Comment");
+      cardRecordStub = sandbox.stub(CR, 'cardRecordFunctions').resolves()
+      getCardsStub = sandbox.stub(CR, 'getCards').resolves([helpers.mockCommentCardObj])
       return
 
-    afterEach ->
-      sandbox.restore()
-      return
-
-    it 'will run the cardRecorder class for a list that has moved recently', (done) ->
-      # Set the action date to less than a day ago
-      # to trigger the phase change
-      cardActions = JSON.parse(JSON.stringify(helpers.actionListMove)) #clone to avoid issues with the tests below
-      commentActions = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
-      cardActions = cardActions.concat(commentActions)
-      hasMovedStub = sandbox.stub(CR, 'hasMovedCheck').returns(true)
-      cardActions.forEach (action) ->
-        action.date = (new Date(Date.now() - 21600000)).toISOString();
-        return
-      findLastStub = sandbox.stub(CR, 'findLastMoveDateFromComments').returns(cardActions[0].date);
-      getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', name: 'BPA Project - Phase II', actions: cardActions}])
-      CR.run().then ->
-        expect(getCards.callCount).to.equal 1
-        expect(deleteCards.callCount).to.equal 1
-        expect(compileStub.callCount).to.equal 1
-        # expect(compileStub.calledWith('cccc', lastListStub, lastListStub, findLastStub, findLastStub, true, 55)).to.be.ok
-        done()
-        return
-      return
-
-    it 'will run the cardRecorder class for a list that has not moved', (done) ->
-      cardActions = helpers.actionListNoMove.concat(helpers.mockCommentCardObj.actions)
-      hasMovedStub = sandbox.stub(CR, 'hasMovedCheck').returns(false)
-      getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', name: 'BPA Project - Phase II', actions: cardActions}])
+    it 'will card record for every card on the board', (done) ->
       CR.run().then (resp) ->
-        expect(deleteCards.callCount).to.equal 1
-        expect(compileStub.callCount).to.equal 1
+        expect(cardRecordStub.callCount).to.eql 1
+        expect(getCards.callCount).to.eql 1
         done()
         return
       return
     return
 
-  describe '.getUpdateCards()', ->
-    sandbox = undefined
+  # describe.skip '.runOLD', ->
+  #   getCards = undefined
+  #   prevListStub = undefined
+  #   findPrevStub = undefined
+  #
+  #   beforeEach ->
+  #     deleteCards = sandbox.stub(CR, 'deleteCurrentComment').resolves({"currentCommentDeleted": true});
+  #     sandbox.stub(CR, 'getListNameByID').resolves('list name');
+  #     prevListStub = sandbox.stub(CR, 'getLastList').returns("Last List")
+  #     compileStub = sandbox.stub(CR, 'compileCommentArtifact').resolves("Compiled Comment");
+  #     return
+  #
+  #   afterEach ->
+  #     sandbox.restore()
+  #     return
+  #
+  #   it 'will run the cardRecorder class for a list that has moved recently', (done) ->
+  #     # Set the action date to less than a day ago
+  #     # to trigger the phase change
+  #     cardActions = JSON.parse(JSON.stringify(helpers.actionListMove)) #clone to avoid issues with the tests below
+  #     commentActions = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
+  #     cardActions = cardActions.concat(commentActions)
+  #     hasMovedStub = sandbox.stub(CR, 'hasMovedCheck').returns(true)
+  #     cardActions.forEach (action) ->
+  #       action.date = (new Date(Date.now() - 21600000)).toISOString();
+  #       return
+  #     findPrevStub = sandbox.stub(CR, 'findPrevMoveDateFromComments').returns(cardActions[0].date);
+  #     getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', name: 'BPA Project - Phase II', actions: cardActions}])
+  #     CR.run().then ->
+  #       expect(getCards.callCount).to.equal 1
+  #       expect(deleteCards.callCount).to.equal 1
+  #       expect(compileStub.callCount).to.equal 1
+  #       # expect(compileStub.calledWith('cccc', prevListStub, prevListStub, findPrevStub, findPrevStub, true, 55)).to.be.ok
+  #       done()
+  #       return
+  #     return
+  #
+  #   it 'will run the cardRecorder class for a list that has not moved', (done) ->
+  #     cardActions = helpers.actionListNoMove.concat(helpers.mockCommentCardObj.actions)
+  #     hasMovedStub = sandbox.stub(CR, 'hasMovedCheck').returns(false)
+  #     getCards = sandbox.stub(CR, 'getUpdateCards').resolves([{id: 'cccc', idList: 'vvv', name: 'BPA Project - Phase II', actions: cardActions}])
+  #     CR.run().then (resp) ->
+  #       expect(deleteCards.callCount).to.equal 1
+  #       expect(compileStub.callCount).to.equal 1
+  #       done()
+  #       return
+  #     return
+  #   return
+
+  describe '.getCards()', ->
     stub = undefined
     error = null
     cards = [ 'card1', 'card2', 'card3' ];
 
     beforeEach ->
-      sandbox = sinon.sandbox.create();
       stub = sandbox.stub(trello.prototype, 'get').yieldsAsync(error, cards)
       return
 
     afterEach ->
-      sandbox.restore()
       error = new Error('Test Error')
       return
 
     it 'will ping trello and get the updated actions of a card', (done) ->
-      CR.getUpdateCards().then (resp) ->
+      CR.getCards().then (resp) ->
         expect(stub.callCount).to.eql 1
         expect(resp).to.eql cards
         done()
@@ -94,7 +113,51 @@ describe 'app.CardRecorder', ->
       return
 
     it 'will survive a trello error', (done) ->
-      CR.getUpdateCards().catch (err) ->
+      CR.getCards().catch (err) ->
+        expect(stub.callCount).to.eql 1
+        expect(err).to.eql error
+        done()
+        return
+      return
+    return
+
+  describe '.cardRecordFunctions(card)', ->
+    deleteStub = undefined
+    hasMovedStub = undefined
+    calcTotalStub = undefined
+    findPrevStub = undefined
+    finalListStub = undefined
+    decideStub = undefined
+    cardMock = undefined
+    cardActions = undefined
+
+
+    beforeEach ->
+      deleteCards = sandbox.stub(CR, 'deleteCurrentComment').resolves({"currentCommentDeleted": true})
+      hasMovedStub = sandbox.stub(CR, 'hasMovedCheck').returns(true)
+      calcTotalStub = sandbox.stub(CR, 'calcTotalDays').returns(55)
+      decideStub = sandbox.stub(CR, 'decideCommentType').resolves()
+      finalListStub = sandbox.stub(CR, 'inFinalList').resolves(false);
+      cardActions = helpers.actionListNoMove.concat(helpers.mockCommentCardObj.actions)
+      cardMock = {id: 'cccc', idList: 'vvv', name: 'BPA Project - Phase II', actions: cardActions}
+      cardActions.forEach (action) ->
+        action.date = (new Date(Date.now() - 21600000)).toISOString();
+        return
+      findPrevStub = sandbox.stub(CR, 'findPrevMoveDateFromComments').returns(cardActions[0].date);
+      return
+
+
+    it 'runs the card record for a single card', (done) ->
+      CR.cardRecordFunctions(cardMock).then (resp) ->
+        expect(deleteCards.callCount).to.equal 1
+        expect(calcTotalStub.callCount).to.equal 1
+        expect(decideStub.callCount).to.equal 1
+        expect(finalListStub.callCount).to.equal 1
+        done()
+      return
+
+    it 'will survive a trello error', (done) ->
+      CR.cardRecordFunctions(cardMock).catch (err) ->
         expect(stub.callCount).to.eql 1
         expect(err).to.eql error
         done()
@@ -104,7 +167,6 @@ describe 'app.CardRecorder', ->
 
   describe '.deleteCurrentComment(comments)', ->
     runs = 0
-    sandbox = undefined
     delStub = undefined
     currentComments = undefined
     notCurrentComments = undefined
@@ -114,7 +176,6 @@ describe 'app.CardRecorder', ->
       currentComments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
       notCurrentComments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
       notCurrentComments[0].data.text = "This comment is not in the current stage."
-      sandbox = sinon.sandbox.create()
       delStub = sandbox.stub(trello.prototype, 'del').withArgs('/1/actions/' + currentComments[0].id).yieldsAsync(null, {})
 
       runs++
@@ -122,9 +183,6 @@ describe 'app.CardRecorder', ->
         delStub.withArgs('/1/actions/' + currentComments[0].id).yieldsAsync(error, null)
       return
 
-    afterEach ->
-      sandbox.restore()
-      return
 
     it 'will delete a comment if a bolded text saying "Current Stage" appears', (done) ->
       CR.deleteCurrentComment(currentComments).then (data) ->
@@ -163,16 +221,16 @@ describe 'app.CardRecorder', ->
       return
     return
 
-  describe '.getLastList(updateActionID)', ->
+  describe '.getPreviousList(updateActionID)', ->
     it 'will grab the name of the last list a trello card was part of given that the card has moved', ->
-      listName = CR.getLastList helpers.actionListMove[1]
+      listName = CR.getPreviousList helpers.actionListMove[1]
       expect(listName).to.equal("Old List")
       return
 
     # get this should be undefined
     it 'will return an error if the action does not have a list before', ->
       expect(->
-        CR.getLastList helpers.actionListMove[0]
+        CR.ggetPreviousList helpers.actionListMove[0]
       ).to.throw Error
       return
     return
@@ -198,17 +256,45 @@ describe 'app.CardRecorder', ->
       return
     return
 
+  describe '.decideCommentType(card, finalList, daysSinceUpdate, hasMoved, prevMove, updateActions, totalDays, nowMoment)', ->
+
+    it 'chooses that a comment should be written to last list phase', (done) ->
+      CR.decideCommentType(card, true, 10, true, prevMove, updateActions, 10, nowMoment).then (resp) ->
+        # expect
+        done()
+      return
+    it 'chooses that a comment should be written to a new phase', (done) ->
+      CR.decideCommentType(card, false, 0, true, prevMove, updateActions, 10, nowMoment).then (resp) ->
+        # expect
+        done()
+      return
+
+    it 'chooses that a comment should be written to a current phase that has moved', (done) ->
+      CR.decideCommentType(card, false, 0, true, prevMove, updateActions, 10, nowMoment).then (resp) ->
+        # expect
+        done()
+      return
+
+    it 'chooses that a comment should be written to a current phase that has not moved', (done) ->
+      CR.decideCommentType(card, false, 0, true, prevMove, updateActions, 10, nowMoment).then (resp) ->
+        # expect
+        done()
+      return
+
+    it 'survives a trello error', (done) ->
+      CR.decideCommentType(card, false, 0, true, prevMove, updateActions, 10, nowMoment).then (resp) ->
+        # expect
+        done()
+      return
+    return
+
   describe '.compileCommentArtifact(cardID, dateList, nameList, fromDate, toDate, addCommentOpt)', ->
-    sandbox = undefined
     addComment = undefined
+
     beforeEach ->
-      sandbox = sinon.sandbox.create()
       addComment = sandbox.stub(CR, 'addComment').resolves();
       calcStub = sandbox.stub(CR, 'calculateDateDifference').returns([103,113]);
       comments = undefined
-      return
-    afterEach ->
-      sandbox.restore()
       return
 
     it 'will run the date diff functions, build and post a comment', (done) ->
@@ -239,8 +325,8 @@ describe 'app.CardRecorder', ->
 
     it 'will check if a comment has a date and return the lastest date from a comment list', ->
       lastMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
-      lastMove = CR.checkCommentsForDates(helpers.mockCommentCardObj.actions, true)
-      expect(lastMove).to.eql lastMoment
+      prevMove = CR.checkCommentsForDates(helpers.mockCommentCardObj.actions, true)
+      expect(prevMove).to.eql lastMoment
       return
 
     it 'will check if a comment has a date and return the first date from a comment list', ->
@@ -250,46 +336,74 @@ describe 'app.CardRecorder', ->
         id: '2'
         data: text: '**IAA Stage:** `+19 days`. *01/02/2016 - 03/08/2016*. Expected days: 2 days. Actual Days spent: 21.'
       commentList.push oldComment
-      lastMove = CR.checkCommentsForDates(commentList, false)
-      expect(lastMove).to.eql localMoment
+      prevMove = CR.checkCommentsForDates(commentList, false)
+      expect(prevMove).to.eql localMoment
       return
 
     it 'will return false when there is no comment that matches the date string', ->
       comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
       comments[0].data.text = "This comment has no date."
-      lastMove = CR.checkCommentsForDates(comments, true)
-      expect(lastMove).to.be.false
+      prevMove = CR.checkCommentsForDates(comments, true)
+      expect(prevMove).to.be.false
       return
     return
 
-  describe 'findLastMoveDateFromComments(opts)', ->
+  describe 'findPrevMoveDateFromComments(opts)', ->
 
     it 'will return the date if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
       localMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
-      lastMove = CR.findLastMoveDateFromComments({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
-      expect(lastMove).to.eql localMoment
+      prevMove = CR.findPrevMoveDateFromComments({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
+      expect(prevMove).to.eql localMoment
       return
 
     it 'will return the last Action date is there is actionList and there is no date in the commentcard', ->
       comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
       comments[0].data.text = "This comment has no date."
-      lastMove = CR.findLastMoveDateFromComments({"commentList": comments, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
-      expect(lastMove).to.eql '2016-02-25T22:00:35.866Z'
+      prevMove = CR.findPrevMoveDateFromComments({"commentList": comments, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
+      expect(prevMove).to.eql '2016-02-25T22:00:35.866Z'
       return
 
     it 'will return the creation date if there is no actionList or no current comment', ->
       comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
       comments[0].data.text = "This comment has no date."
-      lastMove = CR.findLastMoveDateFromComments({"commentList": comments, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
-      expect(lastMove).to.eql '2016-04-05T10:40:26.100Z'
+      prevMove = CR.findPrevMoveDateFromComments({"commentList": comments, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
+      expect(prevMove).to.eql '2016-04-05T10:40:26.100Z'
       return
 
     it 'will return "01/01/2016 if there is nothing in the options', ->
       comments = helpers.mockCommentCardObj.actions
       comments[0].data.text = "This comment has no date."
       localMoment = moment("2016-01-01").toISOString()
-      lastMove = CR.findLastMoveDateFromComments({})
-      expect(lastMove).to.eql localMoment
+      prevMove = CR.findPrevMoveDateFromComments({})
+      expect(prevMove).to.eql localMoment
+      return
+    return
+
+  describe '.inFinalList(cardIDList)', ->
+    stages = undefined
+    stageName = undefined
+
+    it 'returns true if the card is in the last list', (done) ->
+      stages = helpers.expectedStageObject.stages[0].substages[1]
+      # lastStage = stages[stages.length -1]
+      stageName = sandbox.stub(CR, 'getListNameByID').resolves(stages)
+      CR.inFinalList('xxx').then (isInFinalList) ->
+        expect(isInFinalList).to.be.true
+        done()
+      return
+
+    it 'returns false if the card is not in the last list of the board', (done) ->
+      stages = helpers.expectedStageObject.stages[0].substages[0]
+      stageName = sandbox.stub(CR, 'getListNameByID').resolves(stages)
+      CR.inFinalList('xxx').then (isInFinalList) ->
+        expect(isInFinalList).to.be.false
+        done()
+      return
+
+    it 'survives a trello error', ->
+      CR.inFinalList('aaa').catch (err) ->
+        expect(err).to.eql error
+        done()
       return
     return
 
@@ -321,15 +435,13 @@ describe 'app.CardRecorder', ->
     return
 
   describe '.addComment', ->
-    sandbox = undefined
     error = null
 
     beforeEach ->
-      sandbox = sinon.sandbox.create().stub(trello.prototype, 'post').yieldsAsync(error, helpers.createCommentResp)
+      postStub = sandbox.stub(trello.prototype, 'post').yieldsAsync(error, helpers.createCommentResp)
       return
 
     afterEach ->
-      sandbox.restore()
       error = new Error('Test Error')
       return
 

--- a/test/test-date-comment-helpers.coffee
+++ b/test/test-date-comment-helpers.coffee
@@ -1,0 +1,127 @@
+expect = require('chai').expect
+app = require('../app')
+helpers = require('./test-helpers.js')
+q = require('q')
+trello = require('node-trello')
+sinon = require('sinon')
+moment = require('moment')
+require('sinon-as-promised')
+DateCommentHelpers = new app.DateCommentHelpers()
+
+describe 'app.DateCommentHelpers', ->
+  describe '.hasMovedCheck(actionList)', ->
+    it 'will return true if a card has a list of acitons that has not moved', ->
+      hasMoved = DateCommentHelpers.hasMovedCheck(helpers.actionListMove)
+      expect(hasMoved).to.eql [helpers.actionListMove[1]]
+      return
+
+    it 'will return false if a card has a list of acitons that has not moved', ->
+      hasMoved = DateCommentHelpers.hasMovedCheck(helpers.actionListNoMove)
+      expect(hasMoved).to.be.false
+      return
+    return
+
+  describe 'checkCommentsForDates(commentList, latest)', ->
+    beforeEach ->
+      localMoment = undefined
+      return
+    afterEach ->
+      localMoment = null
+      return
+
+    it 'will check if a comment has a date and return the lastest date from a comment list', ->
+      lastMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
+      prevMove = DateCommentHelpers.checkCommentsForDates(helpers.mockCommentCardObj.actions, true)
+      expect(prevMove).to.eql lastMoment
+      return
+
+    it 'will check if a comment has a date and return the first date from a comment list', ->
+      localMoment = moment("2016-01-02").toISOString(); #to get out of localization of test suite
+      commentList = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions)) #clone to modify
+      oldComment =
+        id: '2'
+        data: text: '**IAA Stage:** `+19 days`. *01/02/2016 - 03/08/2016*. Expected days: 2 days. Actual Days spent: 21.'
+      commentList.push oldComment
+      prevMove = DateCommentHelpers.checkCommentsForDates(commentList, false)
+      expect(prevMove).to.eql localMoment
+      return
+
+    it 'will return false when there is no comment that matches the date string', ->
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
+      comments[0].data.text = "This comment has no date."
+      prevMove = DateCommentHelpers.checkCommentsForDates(comments, true)
+      expect(prevMove).to.be.false
+      return
+    return
+
+  describe 'findPrevMoveDateFromComments(opts)', ->
+
+    it 'will return the date if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
+      localMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
+      prevMove = DateCommentHelpers.findPrevMoveDateFromComments({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
+      expect(prevMove).to.eql localMoment
+      return
+
+    it 'will return the last Action date is there is actionList and there is no date in the commentcard', ->
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
+      comments[0].data.text = "This comment has no date."
+      prevMove = DateCommentHelpers.findPrevMoveDateFromComments({"commentList": comments, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
+      expect(prevMove).to.eql '2016-02-25T22:00:35.866Z'
+      return
+
+    it 'will return the creation date if there is no actionList or no current comment', ->
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
+      comments[0].data.text = "This comment has no date."
+      prevMove = DateCommentHelpers.findPrevMoveDateFromComments({"commentList": comments, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
+      expect(prevMove).to.eql '2016-04-05T10:40:26.100Z'
+      return
+
+    it 'will return "01/01/2016 if there is nothing in the options', ->
+      comments = helpers.mockCommentCardObj.actions
+      comments[0].data.text = "This comment has no date."
+      localMoment = moment("2016-01-01").toISOString()
+      prevMove = DateCommentHelpers.findPrevMoveDateFromComments({})
+      expect(prevMove).to.eql localMoment
+      return
+    return
+
+  describe '.calcTotalDays(commentList, nowMoment)', ->
+    it 'calculates takes a comment list and finds the oldest date and then calculates the total number of business days', ->
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions)) #clone to modify
+      oldComment =
+        id: '2'
+        data: text: '**IAA Stage:** `+19 days`. *01/02/2016 - 03/08/2016*. Expected days: 2 days. Actual Days spent: 21.'
+      comments.push oldComment
+      fakeNow = moment("2016-10-10")
+      totalDays = DateCommentHelpers.calcTotalDays(comments, fakeNow)
+      expect(totalDays).to.eql 195
+      return
+
+    it 'will return 0 if the comment list does not have and "MM/DD/YYYY - MM/DD/YYYY" regular expressions in the text', ->
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
+      comments[0].data.text = "This comment has no date."
+      fakeNow = moment("2016-10-10")
+      totalDays = DateCommentHelpers.calcTotalDays(comments, fakeNow)
+      expect(totalDays).to.eql 0
+      return
+    return
+
+  describe '.calculateDateDifference', ->
+    it 'calculates the difference between when the card was moved and the expected time', ->
+      difference = DateCommentHelpers.calculateDateDifference(10, "2016-04-05", "2016-07-27")
+      expect(difference).to.eql [69,79]
+      return
+    return
+
+  describe '.findHolidaysBetweenDates', ->
+    it 'will not find a holiday between dates that do not have a holiday between them', ->
+      holidays = DateCommentHelpers.findHolidaysBetweenDates(new Date('01-04-2016'), new Date('01-10-2016'))
+      expect(holidays).to.eql 0
+      return
+
+    it 'will find that there are two holidays between 4/5/16 and 7/27/16', ->
+      holidays = DateCommentHelpers.findHolidaysBetweenDates(new Date('2016-04-05'), new Date('2016-07-27'))
+      expect(holidays).to.eql 2
+      return
+    return
+  return


### PR DESCRIPTION
* [x] Make `.run()` just a wrapper for `getCards()` and `cardRecordFunctions()` that resolves once all the card promises are done
* [x] Create new `cardRecordFunction(card)` method to handle the recording of each card
* [x] Create new `decideCommentType()` method to allow for more extensible handling of end of board cards
* [x] break out `CardRecorder` into two classes, one for the more recording, updating, and asynchronous processes, and one for the synchronous date processes.
* [ ] passing tests for refactor.