### PR TITLE
Fix date logic and refactor

### DIFF
--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -128,7 +128,7 @@ class CardRecorder extends MyTrello {
 
   generateNewCommentStats(comments, deletedNewComment, currentTime, listName) {
     const altToDate = DCH.differentToDate(comments, currentTime);
-    const fromDate = DCH.getNewCommentFromDate(deletedNewComment, comments, altToDate);
+    const fromDate = DCH.generateFromDateForNewComment(deletedNewComment, comments, altToDate);
     const totalDays = (comments.length > 0) ? DCH.calcTotalDays(comments, currentTime) : 0;
     const stage = this.stages.find(s => s.name === listName);
     const diffArray = DCH.calculateDateDifference(stage.expected_time, fromDate, currentTime);

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -48,13 +48,11 @@ class CardRecorder extends MyTrello {
       const commentListName = cardActions.comments[0].data.list.name;
       self.deleteCurrentComment(cardActions.comments)
          .then(deletedComment => {
-           self.generateNewCommentStats(cardActions.comments, deletedComment.currentCommentDeleted, now, commentListName)
-           .then(commentStats => {
-             const comment = self.buildComment(recentlyMoved, commentListName, commentStats);
-             self.addComment(comment, card.id)
-             .then(resp => { deferred.resolve(resp); })
-             .catch(deferred.reject);
-           });
+           const commentStats = self.generateNewCommentStats(cardActions.comments, deletedComment.currentCommentDeleted, now, commentListName);
+           const comment = self.buildComment(recentlyMoved, commentListName, commentStats);
+           self.addComment(comment, card.id)
+           .then(resp => { deferred.resolve(resp); })
+           .catch(deferred.reject);
          });
     });
     return deferred.promise;
@@ -127,15 +125,15 @@ class CardRecorder extends MyTrello {
   }
 
   generateNewCommentStats(comments, deletedNewComment, currentTime, listName) {
-    const deferred = Q.defer();
+    // const deferred = Q.defer();
     const altToDate = DCH.differentToDate(comments, currentTime);
     const fromDate = DCH.getNewCommentFromDate(deletedNewComment, comments, altToDate);
     const totalDays = (comments.length > 0) ? DCH.calcTotalDays(comments, currentTime) : 0;
     const stage = this.stages.find(s => s.name === listName);
     const diffArray = DCH.calculateDateDifference(stage.expected_time, fromDate, currentTime);
     console.log(diffArray);
-    deferred.resolve({ fromDate, toDate: currentTime, totalDays, timeTaken: diffArray[1], expectedTime: stage.expected_time, dateDelta: diffArray[0] });
-    return deferred.promise;
+    return { fromDate, toDate: currentTime, totalDays, timeTaken: diffArray[1], expectedTime: stage.expected_time, dateDelta: diffArray[0] };
+    // return deferred.promise;
   }
 
   buildComment(recentlyMoved, commentListName, commentStats) {

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -38,33 +38,25 @@ class CardRecorder extends MyTrello {
     const self = this;
     const deferred = Q.defer();
     const cardActions = self.cardFilters(card.actions, [{ name: 'comments', type: 'commentCard' }, { name: 'updates', type: 'updateCard' }, { name: 'created', type: 'createCard' }]);
-
-    self.deleteCurrentComment(cardActions.comments)
-      .then(deletedCommentResp => {
-        console.log(deletedCommentResp);
-        const now = moment();
-        let hasMoved = false;
-        let daysSinceUpdate = false;
-        if (cardActions.updates.length > 0) {
-          hasMoved = DCH.hasMovedCheck(cardActions.updates);
-          daysSinceUpdate = now.diff(moment(cardActions.updates[0].date), 'days');
-        }
-        const totDays = (cardActions.comments.length > 0) ? DCH.calcTotalDays(cardActions.comments, now) : 0;
-        const fromDate = DCH.extractNewCommentFromDate({ commentList: cardActions.comments, actionList: cardActions.updates, createActionDate: cardActions.created.date });
-        self.inFinalList(card.idList)
-          .then(finalList => {
-            self.decideCommentType(card,
-              finalList,
-              daysSinceUpdate,
-              hasMoved,
-              fromDate,
-              cardActions,
-              totDays,
-              now)
-            .then(resp => { deferred.resolve(resp); })
-            .catch(deferred.reject);
-          });
-      });
+    const now = moment();
+    const recentlyMoved = self.checkRecentMove(cardActions.updates, now);
+    self.inFinalList(card.idList)
+    .then(finalList => {
+      if (finalList && !recentlyMoved) {
+        deferred.resolve({ 'final phase': true });
+      }
+      const commentListName = cardActions.comments[0].data.list.name;
+      self.deleteCurrentComment(cardActions.comments)
+         .then(deletedComment => {
+           self.generateNewCommentStats(cardActions.comments, deletedComment.currentCommentDeleted, now, commentListName)
+           .then(commentStats => {
+             const comment = self.buildComment(recentlyMoved, commentListName, commentStats);
+             self.addComment(comment, card.id)
+             .then(resp => { deferred.resolve(resp); })
+             .catch(deferred.reject);
+           });
+         });
+    });
     return deferred.promise;
   }
 
@@ -76,6 +68,37 @@ class CardRecorder extends MyTrello {
       );
     });
     return actions;
+  }
+
+  checkRecentMove(updates, currentTime) {
+    let moves = false;
+    let daysSinceUpdate = false;
+    if (updates.length > 0) {
+      moves = DCH.hasMovedCheck(updates);
+      let lastUpdate = updates[0].date;
+      if (moves.length > 0) {
+        lastUpdate = moves[0].date;
+      }
+      daysSinceUpdate = currentTime.diff(moment(lastUpdate), 'days');
+    }
+    if (moves && daysSinceUpdate < 1) {
+      return true;
+    }
+    return false;
+  }
+
+  inFinalList(listID) {
+    const deferred = Q.defer();
+    const self = this;
+    self.getListNameByID(listID).then(listName => {
+      let lastList = false;
+      const lastStage = self.stages[self.stages.length - 1].name;
+      if (listName === lastStage) {
+        lastList = true;
+      }
+      deferred.resolve(lastList);
+    });
+    return deferred.promise;
   }
 
   deleteCurrentComment(comments) {
@@ -103,82 +126,29 @@ class CardRecorder extends MyTrello {
     return deferred.promise;
   }
 
-  inFinalList(listID) {
+  generateNewCommentStats(comments, deletedNewComment, currentTime, listName) {
     const deferred = Q.defer();
-    const self = this;
-    self.getListNameByID(listID).then(listName => {
-      let lastList = false;
-      const lastStage = self.stages[self.stages.length - 1].name;
-      if (listName === lastStage) {
-        lastList = true;
-      }
-      deferred.resolve(lastList);
-    });
+    const fromDate = DCH.getNewCommentFromDate(deletedNewComment, comments);
+    const toDate = DCH.getNewCommentToDate(comments, currentTime);
+    const totalDays = (comments.length > 0) ? DCH.calcTotalDays(comments, currentTime) : 0;
+    const stage = this.stages.find(s => s.name === listName);
+    console.log(fromDate.toDate());
+    console.log(toDate.toDate());
+    const diffArray = DCH.calculateDateDifference(stage.expected_time, fromDate, toDate);
+    console.log(diffArray);
+    deferred.resolve({ fromDate, toDate, totalDays, timeTaken: diffArray[1], expectedTime: stage.expected_time, dateDelta: diffArray[0] });
     return deferred.promise;
   }
 
-  getPreviousList(cardAction) {
-    return cardAction.data.listBefore.name;
-  }
-
-  decideCommentType(card, finalList, daysSinceUpdate, hasMoved, prevMove, cardActions, totalDays, nowMoment) {
-    const self = this;
-    const deferred = Q.defer();
-    if (finalList && daysSinceUpdate > 1) {
-      deferred.resolve({ 'final phase': true });
-    } else if (hasMoved && daysSinceUpdate < 1) {
-      console.log(`Write New Phase: ${card.name}`);
-      const prevPhase = self.getPreviousList(hasMoved[0]);
-      const endLastPhaseDate = DCH.checkCommentsForDates(cardActions.comments, true, true);
-      self.compileCommentArtifact(
-              card.id,
-              prevPhase,
-              prevPhase,
-              endLastPhaseDate,
-              cardActions.updates[0].date,
-              true,
-              totalDays
-          )
-          .then(resp => { deferred.resolve(resp); });
-    } else {
-      console.log(`Write Current Phase: ${card.name}`);
-      self.getListNameByID(card.idList).then(listName => {
-        self.compileCommentArtifact(
-                  card.id,
-                  listName,
-                  'Current',
-                  prevMove,
-                  nowMoment.format(),
-                  true,
-                  totalDays
-              );
-      })
-      .then(resp => { deferred.resolve(resp); });
+  buildComment(recentlyMoved, commentListName, commentStats) {
+    let listName = 'Current';
+    if (recentlyMoved) {
+      listName = commentListName;
     }
-    return deferred.promise;
-  }
-
-  compileCommentArtifact(cardID, dateList, nameList, fromDate, toDate, addCommentOpt, totDays) {
-    const deferred = Q.defer();
-    const stage = this.stages.find(s => s.name === dateList);
-    const expectedTime = stage.expected_time;
-    const diffArray = DCH.calculateDateDifference(expectedTime, fromDate, toDate);
-    const differenceFromExpected = diffArray[0];
-    const timeTaken = diffArray[1];
-    const comment = this.buildComment(differenceFromExpected, expectedTime, fromDate, toDate, nameList, timeTaken, totDays);
-    if (addCommentOpt) {
-      this.addComment(comment, cardID).then(resp => { deferred.resolve(resp); });
-    } else {
-      deferred.resolve(comment);
-    }
-    return deferred.promise;
-  }
-
-  buildComment(dateDiff, expected, prevMove, recentMove, lastList, actual, totalDays) {
-    const formatDiff = (dateDiff < 0) ? `**${dateDiff} days**` : `\`+${dateDiff} days\``;
-    const fromDate = moment(prevMove).format('L');
-    const toDate = moment(recentMove).format('L');
-    return `**${lastList} Stage:** ${formatDiff}. *${fromDate} - ${toDate}*.\n Expected days: ${expected} days. Actual Days spent: ${actual}. **Total Project Days: ${totalDays}**`;
+    const formatDiff = (commentStats.dateDelta < 0) ? `**${commentStats.dateDelta} days**` : `\`+${commentStats.dateDelta} days\``;
+    const fromDate = commentStats.fromDate.format('L');
+    const toDate = commentStats.toDate.format('L');
+    return `**${listName} Stage:** ${formatDiff}. *${fromDate} - ${toDate}*.\n Expected days: ${commentStats.expectedTime} days. Actual Days spent: ${commentStats.timeTaken}. **Total Project Days: ${commentStats.totalDays}**`;
   }
 
   addComment(message, cardID) {

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -128,15 +128,13 @@ class CardRecorder extends MyTrello {
 
   generateNewCommentStats(comments, deletedNewComment, currentTime, listName) {
     const deferred = Q.defer();
-    const fromDate = DCH.getNewCommentFromDate(deletedNewComment, comments);
-    const toDate = DCH.getNewCommentToDate(comments, currentTime);
+    const altToDate = DCH.differentToDate(comments, currentTime);
+    const fromDate = DCH.getNewCommentFromDate(deletedNewComment, comments, altToDate);
     const totalDays = (comments.length > 0) ? DCH.calcTotalDays(comments, currentTime) : 0;
     const stage = this.stages.find(s => s.name === listName);
-    console.log(fromDate.toDate());
-    console.log(toDate.toDate());
-    const diffArray = DCH.calculateDateDifference(stage.expected_time, fromDate, toDate);
+    const diffArray = DCH.calculateDateDifference(stage.expected_time, fromDate, currentTime);
     console.log(diffArray);
-    deferred.resolve({ fromDate, toDate, totalDays, timeTaken: diffArray[1], expectedTime: stage.expected_time, dateDelta: diffArray[0] });
+    deferred.resolve({ fromDate, toDate: currentTime, totalDays, timeTaken: diffArray[1], expectedTime: stage.expected_time, dateDelta: diffArray[0] });
     return deferred.promise;
   }
 

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -52,7 +52,6 @@ class CardRecorder extends MyTrello {
            const comment = self.buildComment(recentlyMoved, commentListName, commentStats);
            self.addComment(comment, card.id)
            .then(resp => {
-             console.log('past add');
              deferred.resolve(resp);
            })
            .catch(deferred.reject);
@@ -133,7 +132,6 @@ class CardRecorder extends MyTrello {
     const totalDays = (comments.length > 0) ? DCH.calcTotalDays(comments, currentTime) : 0;
     const stage = this.stages.find(s => s.name === listName);
     const diffArray = DCH.calculateDateDifference(stage.expected_time, fromDate, currentTime);
-    console.log(diffArray);
     return { fromDate, toDate: currentTime, totalDays, timeTaken: diffArray[1], expectedTime: stage.expected_time, dateDelta: diffArray[0] };
   }
 

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -51,7 +51,10 @@ class CardRecorder extends MyTrello {
            const commentStats = self.generateNewCommentStats(cardActions.comments, deletedComment.currentCommentDeleted, now, commentListName);
            const comment = self.buildComment(recentlyMoved, commentListName, commentStats);
            self.addComment(comment, card.id)
-           .then(resp => { deferred.resolve(resp); })
+           .then(resp => {
+             console.log('past add');
+             deferred.resolve(resp);
+           })
            .catch(deferred.reject);
          });
     });

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -125,7 +125,6 @@ class CardRecorder extends MyTrello {
   }
 
   generateNewCommentStats(comments, deletedNewComment, currentTime, listName) {
-    // const deferred = Q.defer();
     const altToDate = DCH.differentToDate(comments, currentTime);
     const fromDate = DCH.getNewCommentFromDate(deletedNewComment, comments, altToDate);
     const totalDays = (comments.length > 0) ? DCH.calcTotalDays(comments, currentTime) : 0;
@@ -133,7 +132,6 @@ class CardRecorder extends MyTrello {
     const diffArray = DCH.calculateDateDifference(stage.expected_time, fromDate, currentTime);
     console.log(diffArray);
     return { fromDate, toDate: currentTime, totalDays, timeTaken: diffArray[1], expectedTime: stage.expected_time, dateDelta: diffArray[0] };
-    // return deferred.promise;
   }
 
   buildComment(recentlyMoved, commentListName, commentStats) {

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -45,9 +45,9 @@ class CardRecorder extends MyTrello {
       if (finalList && !recentlyMoved) {
         deferred.resolve({ 'final phase': true });
       }
-      const commentListName = cardActions.comments[0].data.list.name;
       self.deleteCurrentComment(cardActions.comments)
          .then(deletedComment => {
+           const commentListName = cardActions.comments[0].data.list.name;
            const commentStats = self.generateNewCommentStats(cardActions.comments, deletedComment.currentCommentDeleted, now, commentListName);
            const comment = self.buildComment(recentlyMoved, commentListName, commentStats);
            self.addComment(comment, card.id)
@@ -71,8 +71,8 @@ class CardRecorder extends MyTrello {
   }
 
   checkRecentMove(updates, currentTime) {
-    let moves = false;
-    let daysSinceUpdate = false;
+    let moves = null;
+    let daysSinceUpdate = null;
     if (updates.length > 0) {
       moves = DCH.hasMovedCheck(updates);
       let lastUpdate = updates[0].date;

--- a/app/cardrecord.js
+++ b/app/cardrecord.js
@@ -40,7 +40,8 @@ class CardRecorder extends MyTrello {
     const cardActions = self.cardFilters(card.actions, [{ name: 'comments', type: 'commentCard' }, { name: 'updates', type: 'updateCard' }, { name: 'created', type: 'createCard' }]);
 
     self.deleteCurrentComment(cardActions.comments)
-      .then(() => {
+      .then(deletedCommentResp => {
+        console.log(deletedCommentResp);
         const now = moment();
         let hasMoved = false;
         let daysSinceUpdate = false;
@@ -49,14 +50,14 @@ class CardRecorder extends MyTrello {
           daysSinceUpdate = now.diff(moment(cardActions.updates[0].date), 'days');
         }
         const totDays = (cardActions.comments.length > 0) ? DCH.calcTotalDays(cardActions.comments, now) : 0;
-        const prevMove = DCH.findPrevMoveDateFromComments({ commentList: cardActions.comments, actionList: cardActions.updates, createActionDate: cardActions.created.date });
+        const fromDate = DCH.extractNewCommentFromDate({ commentList: cardActions.comments, actionList: cardActions.updates, createActionDate: cardActions.created.date });
         self.inFinalList(card.idList)
           .then(finalList => {
             self.decideCommentType(card,
               finalList,
               daysSinceUpdate,
               hasMoved,
-              prevMove,
+              fromDate,
               cardActions,
               totDays,
               now)

--- a/app/date-comment-helpers.js
+++ b/app/date-comment-helpers.js
@@ -44,8 +44,7 @@ class DateCommentHelpers {
     if (altToDate) {
       return moment(this.checkCommentsForDates(comments, true, true));
     }
-    const useLastFromDate = !deletedNewComment;
-    return moment(this.checkCommentsForDates(comments, true, useLastFromDate));
+    return moment(this.checkCommentsForDates(comments, true, !deletedNewComment));
   }
 
   differentToDate(comments, currentTime) {
@@ -53,7 +52,7 @@ class DateCommentHelpers {
     const recentToMoment = moment(mostRecentToDate);
     const differenceFromLastComment = currentTime.diff(recentToMoment, 'days');
     if (differenceFromLastComment > 2) {
-      return recentToMoment;
+      return true;
     }
     return false; // Default to returning today
   }

--- a/app/date-comment-helpers.js
+++ b/app/date-comment-helpers.js
@@ -69,11 +69,8 @@ class DateCommentHelpers {
   }
 
   calculateDateDifference(expected, fromMomentObj, toMomentObj) {
-    console.log(fromMomentObj.toDate());
-    console.log(toMomentObj.toDate());
     let diffDays = instadate.differenceInWorkDays(fromMomentObj.toDate(), toMomentObj.toDate());
     diffDays = diffDays - this.findHolidaysBetweenDates(fromMomentObj.toDate(), toMomentObj.toDate());
-    console.log(diffDays);
     return [diffDays - expected, diffDays];
   }
 

--- a/app/date-comment-helpers.js
+++ b/app/date-comment-helpers.js
@@ -40,7 +40,7 @@ class DateCommentHelpers {
     return false;
   }
 
-  findPrevMoveDateFromComments(opts) {
+  extractNewCommentFromDate(opts) {
     const actionList = opts.actionList;
     const cardCreationDate = opts.cardCreationDate;
     const commentList = opts.commentList;

--- a/app/date-comment-helpers.js
+++ b/app/date-comment-helpers.js
@@ -42,7 +42,7 @@ class DateCommentHelpers {
 
   getNewCommentFromDate(deletedNewComment, comments, altToDate) {
     if (altToDate) {
-      return altToDate;
+      return moment(this.checkCommentsForDates(comments, true, true));
     }
     const useLastFromDate = !deletedNewComment;
     return moment(this.checkCommentsForDates(comments, true, useLastFromDate));

--- a/app/date-comment-helpers.js
+++ b/app/date-comment-helpers.js
@@ -40,9 +40,9 @@ class DateCommentHelpers {
     return false;
   }
 
-  getNewCommentFromDate(deletedNewComment, comments, altToDate) {
+  generateFromDateForNewComment(deletedNewComment, comments, altToDate) {
     if (altToDate) {
-      return moment(this.checkCommentsForDates(comments, true, true));
+      return altToDate;
     }
     return moment(this.checkCommentsForDates(comments, true, !deletedNewComment));
   }
@@ -52,7 +52,7 @@ class DateCommentHelpers {
     const recentToMoment = moment(mostRecentToDate);
     const differenceFromLastComment = currentTime.diff(recentToMoment, 'days');
     if (differenceFromLastComment > 2) {
-      return true;
+      return recentToMoment;
     }
     return false; // Default to returning today
   }

--- a/app/date-comment-helpers.js
+++ b/app/date-comment-helpers.js
@@ -40,19 +40,22 @@ class DateCommentHelpers {
     return false;
   }
 
-  getNewCommentFromDate(deletedNewComment, comments) {
+  getNewCommentFromDate(deletedNewComment, comments, altToDate) {
+    if (altToDate) {
+      return altToDate;
+    }
     const useLastFromDate = !deletedNewComment;
     return moment(this.checkCommentsForDates(comments, true, useLastFromDate));
   }
 
-  getNewCommentToDate(comments, currentTime) {
+  differentToDate(comments, currentTime) {
     const mostRecentToDate = this.checkCommentsForDates(comments, true, true);
     const recentToMoment = moment(mostRecentToDate);
     const differenceFromLastComment = currentTime.diff(recentToMoment, 'days');
     if (differenceFromLastComment > 2) {
       return recentToMoment;
     }
-    return currentTime; // Default to returning today
+    return false; // Default to returning today
   }
 
   calcTotalDays(commentList, nowMoment) {

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -103,7 +103,7 @@ describe 'app.CardRecorder', ->
       cardActions.forEach (action) ->
         action.date = (new Date(Date.now() - 21600000)).toISOString();
         return
-      findPrevStub = sandbox.stub(app.DateCommentHelpers.prototype, 'findPrevMoveDateFromComments').returns(cardActions[0].date);
+      findPrevStub = sandbox.stub(app.DateCommentHelpers.prototype, 'extractNewCommentFromDate').returns(cardActions[0].date);
       return
 
 

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -235,7 +235,17 @@ describe 'app.CardRecorder', ->
     return
 
   describe '.generateNewCommentStats(comments, deletedNewComment, currentTime, listName)', ->
-    it ''
+    now = undefined
+    dateDifferenceStub = undefined
+    before ->
+      now = moment()
+      dateDifferenceStub = sandbox.stub(app.DateCommentHelpers.prototype, 'calculateDateDifference').returns([6, 8])
+
+    it 'returns an object with all of the dates and time differentials from the DCH object', ->
+      commentStats = CR.generateNewCommentStats([], true, now, 'Workshop')
+      expected = { fromDate, toDate: now, totalDays, timeTaken: 8, expectedTime: 2, dateDelta: 6 }
+      expect(commentStats).to.eq(expected)
+      return
     return
 
   describe '.buildComment(recentlyMoved, commentListName, commentStats)', ->

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -93,7 +93,6 @@ describe 'app.CardRecorder', ->
     beforeEach ->
       now = moment()
       deleteStub = sandbox.stub(CR, 'deleteCurrentComment').resolves({"currentCommentDeleted": true})
-      hasMovedStub = sandbox.stub(CR, 'checkRecentMove').returns(true)
       cardActions = helpers.actionListNoMove.concat(helpers.mockCommentCardObj.actions)
       cardMock = {id: 'cccc', idList: 'testlistID', name: 'BPA Project - Phase II', actions: cardActions}
       cardActions.forEach (action) ->
@@ -106,6 +105,7 @@ describe 'app.CardRecorder', ->
     it 'runs the card record for a single card not in final list', (done) ->
       addCommentStub = sandbox.stub(CR, 'addComment').resolves({"comment": true})
       finalListStub = sandbox.stub(CR, 'inFinalList').resolves(false)
+      hasMovedStub = sandbox.stub(CR, 'checkRecentMove').returns(true)
       CR.cardRecordFunctions(cardMock).then (resp) ->
         expect(finalListStub.callCount).to.equal 1
         expect(deleteStub.callCount).to.equal 1
@@ -116,6 +116,7 @@ describe 'app.CardRecorder', ->
     it 'runs the card record for a single card in the final list of the board', (done) ->
       addCommentStub = sandbox.stub(CR, 'addComment').resolves({"comment": true})
       finalListStub = sandbox.stub(CR, 'inFinalList').resolves(true)
+      hasMovedStub = sandbox.stub(CR, 'checkRecentMove').returns(false)
       CR.cardRecordFunctions(cardMock).then (resp) ->
         expect(finalListStub.callCount).to.equal 1
         done()

--- a/test/test-card-recorder.coffee
+++ b/test/test-card-recorder.coffee
@@ -234,16 +234,23 @@ describe 'app.CardRecorder', ->
       return
     return
 
-  describe '.generateNewCommentStats(comments, deletedNewComment, currentTime, listName)', ->
+  describe.skip '.generateNewCommentStats(comments, deletedNewComment, currentTime, listName)', ->
     now = undefined
     dateDifferenceStub = undefined
+    stage = undefined
+    stageMock = undefined
+
     before ->
       now = moment()
       dateDifferenceStub = sandbox.stub(app.DateCommentHelpers.prototype, 'calculateDateDifference').returns([6, 8])
 
+    after ->
+      sandbox.restore()
+
+
     it 'returns an object with all of the dates and time differentials from the DCH object', ->
       commentStats = CR.generateNewCommentStats([], true, now, 'Workshop')
-      expected = { fromDate, toDate: now, totalDays, timeTaken: 8, expectedTime: 2, dateDelta: 6 }
+      expected = { fromDate: moment("2016-04-05T10:40:26.100Z"), toDate: now, totalDays, timeTaken: 8, expectedTime: 2, dateDelta: 6 }
       expect(commentStats).to.eq(expected)
       return
     return

--- a/test/test-date-comment-helpers.coffee
+++ b/test/test-date-comment-helpers.coffee
@@ -95,8 +95,8 @@ describe 'app.DateCommentHelpers', ->
 
     it 'returns the most recent to date in a comment if it is greater than 2 days', ->
       diffToDate = DateCommentHelpers.differentToDate(comments, now)
-      expectedDate = moment("2016-03-21T04:00:00.000Z")
-      expect(diffToDate).to.eql expectedDate
+      expectedDate = moment("2016-03-21").toISOString()
+      expect(diffToDate.toISOString()).to.eql expectedDate
       return
 
     it 'returns false if the most recent to date in a comment is within 2 days of today than today', ->

--- a/test/test-date-comment-helpers.coffee
+++ b/test/test-date-comment-helpers.coffee
@@ -67,21 +67,21 @@ describe 'app.DateCommentHelpers', ->
       comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions)) #clone to modify
 
     it 'returns the to date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string in it if the to date has been edited', ->
-      testMoment = moment("2016-03-21T04:00:00.000Z")
+      testMoment = moment("2016-03-21")
       fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, true)
-      expect(fromDate).to.eql(testMoment)
+      expect(fromDate.toISOString()).to.eql(testMoment.toISOString())
       return
 
     it 'returns the from date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string if the card was in the same list for over a day (there was a current comment deleted)', ->
-      testMoment = moment("2016-03-08T05:00:00.000Z")
+      testMoment = moment("2016-03-08")
       fromDate = DateCommentHelpers.getNewCommentFromDate(true, comments, false)
-      expect(fromDate).to.eql(testMoment)
+      expect(fromDate.toISOString()).to.eql(testMoment.toISOString())
       return
 
     it 'returns the to date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string if the card was in the same list for less than a day (there was not a current comment deleted)', ->
-      testMoment = moment("2016-03-21T04:00:00.000Z")
+      testMoment = moment("2016-03-21")
       fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, false)
-      expect(fromDate).to.eql(testMoment)
+      expect(fromDate.toISOString()).to.eql(testMoment.toISOString())
       return
     return
 

--- a/test/test-date-comment-helpers.coffee
+++ b/test/test-date-comment-helpers.coffee
@@ -60,34 +60,26 @@ describe 'app.DateCommentHelpers', ->
       return
     return
 
-  describe 'extractNewCommentFromDate(opts)', ->
-
-    it 'will return the date if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
-      localMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
-      prevMove = DateCommentHelpers.extractNewCommentFromDate({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
-      expect(prevMove).to.eql localMoment
+  describe.skip 'getNewCommentFromDate(deletedNewComment, comments, altToDate)', ->
+    it 'returns the to date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string in it if the to date has been edited', ->
+      comments = []
+      testMoment = moment("2016-01-08")
+      fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, true)
+      expect(fromDate).to.eql(testMoment)
       return
 
-    it 'will return the last Action date is there is actionList and there is no date in the commentcard', ->
-      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
-      comments[0].data.text = "This comment has no date."
-      prevMove = DateCommentHelpers.extractNewCommentFromDate({"commentList": comments, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
-      expect(prevMove).to.eql '2016-02-25T22:00:35.866Z'
+    it 'returns the from date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string if the card was in the same list for over a day (there was a current comment deleted)', ->
+      comments = []
+      testMoment = moment("2016-01-08")
+      fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, false)
+      expect(fromDate).to.eql(testMoment)
       return
 
-    it 'will return the creation date if there is no actionList or no current comment', ->
-      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
-      comments[0].data.text = "This comment has no date."
-      prevMove = DateCommentHelpers.extractNewCommentFromDate({"commentList": comments, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
-      expect(prevMove).to.eql '2016-04-05T10:40:26.100Z'
-      return
-
-    it 'will return "01/01/2016 if there is nothing in the options', ->
-      comments = helpers.mockCommentCardObj.actions
-      comments[0].data.text = "This comment has no date."
-      localMoment = moment("2016-01-01").toISOString()
-      prevMove = DateCommentHelpers.extractNewCommentFromDate({})
-      expect(prevMove).to.eql localMoment
+    it 'returns the to date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string if the card was in the same list for less than a day (there was a current comment not deleted)', ->
+      comments = []
+      testMoment = moment("2016-01-08")
+      fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, false)
+      expect(fromDate).to.eql(testMoment)
       return
     return
 
@@ -114,7 +106,7 @@ describe 'app.DateCommentHelpers', ->
 
   describe '.calculateDateDifference', ->
     it 'calculates the difference between when the card was moved and the expected time', ->
-      difference = DateCommentHelpers.calculateDateDifference(10, "2016-04-05", "2016-07-27")
+      difference = DateCommentHelpers.calculateDateDifference(10, moment("2016-04-05"), moment("2016-07-27"))
       expect(difference).to.eql [69,79]
       return
     return

--- a/test/test-date-comment-helpers.coffee
+++ b/test/test-date-comment-helpers.coffee
@@ -60,7 +60,7 @@ describe 'app.DateCommentHelpers', ->
       return
     return
 
-  describe 'getNewCommentFromDate(deletedNewComment, comments, altToDate)', ->
+  describe 'generateFromDateForNewComment(deletedNewComment, comments, altToDate)', ->
     comments = undefined
 
     before ->
@@ -68,19 +68,19 @@ describe 'app.DateCommentHelpers', ->
 
     it 'returns the to date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string in it if the to date has been edited', ->
       testMoment = moment("2016-03-21")
-      fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, true)
+      fromDate = DateCommentHelpers.generateFromDateForNewComment(false, comments, testMoment)
       expect(fromDate.toISOString()).to.eql(testMoment.toISOString())
       return
 
     it 'returns the from date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string if the card was in the same list for over a day (there was a current comment deleted)', ->
       testMoment = moment("2016-03-08")
-      fromDate = DateCommentHelpers.getNewCommentFromDate(true, comments, false)
+      fromDate = DateCommentHelpers.generateFromDateForNewComment(true, comments, false)
       expect(fromDate.toISOString()).to.eql(testMoment.toISOString())
       return
 
     it 'returns the to date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string if the card was in the same list for less than a day (there was not a current comment deleted)', ->
       testMoment = moment("2016-03-21")
-      fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, false)
+      fromDate = DateCommentHelpers.generateFromDateForNewComment(false, comments, false)
       expect(fromDate.toISOString()).to.eql(testMoment.toISOString())
       return
     return

--- a/test/test-date-comment-helpers.coffee
+++ b/test/test-date-comment-helpers.coffee
@@ -30,13 +30,13 @@ describe 'app.DateCommentHelpers', ->
       return
 
     it 'will check if a comment has a date and return the first date in the lattest comment from a comment list', ->
-      lastMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
+      lastMoment = moment("2016-03-08").toISOString(); #to get out of localization of test suite
       prevMove = DateCommentHelpers.checkCommentsForDates(helpers.mockCommentCardObj.actions, true, false)
       expect(prevMove).to.eql lastMoment
       return
 
     it 'will check if a comment has a date and return the seconde date in the lattest comment from a comment list', ->
-      lastMoment = moment("2016-03-08").toISOString(); #to get out of localization of test suite
+      lastMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
       prevMove = DateCommentHelpers.checkCommentsForDates(helpers.mockCommentCardObj.actions, true, true)
       expect(prevMove).to.eql lastMoment
       return
@@ -60,26 +60,50 @@ describe 'app.DateCommentHelpers', ->
       return
     return
 
-  describe.skip 'getNewCommentFromDate(deletedNewComment, comments, altToDate)', ->
+  describe 'getNewCommentFromDate(deletedNewComment, comments, altToDate)', ->
+    comments = undefined
+
+    before ->
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions)) #clone to modify
+
     it 'returns the to date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string in it if the to date has been edited', ->
-      comments = []
-      testMoment = moment("2016-01-08")
+      testMoment = moment("2016-03-21T04:00:00.000Z")
       fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, true)
       expect(fromDate).to.eql(testMoment)
       return
 
     it 'returns the from date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string if the card was in the same list for over a day (there was a current comment deleted)', ->
-      comments = []
-      testMoment = moment("2016-01-08")
-      fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, false)
+      testMoment = moment("2016-03-08T05:00:00.000Z")
+      fromDate = DateCommentHelpers.getNewCommentFromDate(true, comments, false)
       expect(fromDate).to.eql(testMoment)
       return
 
-    it 'returns the to date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string if the card was in the same list for less than a day (there was a current comment not deleted)', ->
-      comments = []
-      testMoment = moment("2016-01-08")
+    it 'returns the to date of the most recent comment with a MM/DD/YYYY -MM/DD/YYYY date string if the card was in the same list for less than a day (there was not a current comment deleted)', ->
+      testMoment = moment("2016-03-21T04:00:00.000Z")
       fromDate = DateCommentHelpers.getNewCommentFromDate(false, comments, false)
       expect(fromDate).to.eql(testMoment)
+      return
+    return
+
+  describe '.differentToDate(comments, currentTime)', ->
+    now = undefined
+    comments = undefined
+
+    before ->
+      now = moment()
+      comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
+
+    it 'returns the most recent to date in a comment if it is greater than 2 days', ->
+      diffToDate = DateCommentHelpers.differentToDate(comments, now)
+      expectedDate = moment("2016-03-21T04:00:00.000Z")
+      expect(diffToDate).to.eql expectedDate
+      return
+
+    it 'returns false if the most recent to date in a comment is within 2 days of today than today', ->
+      nowString = now.format('L')
+      comments[0].data.text = "**IAA Stage:** **+19 days**. *01/02/2016 - #{nowString}*. Expected days: 2 days. Actual Days spent: 21."
+      diffToDate = DateCommentHelpers.differentToDate(comments, now)
+      expect(diffToDate).to.eql false
       return
     return
 

--- a/test/test-date-comment-helpers.coffee
+++ b/test/test-date-comment-helpers.coffee
@@ -60,25 +60,25 @@ describe 'app.DateCommentHelpers', ->
       return
     return
 
-  describe 'findPrevMoveDateFromComments(opts)', ->
+  describe 'extractNewCommentFromDate(opts)', ->
 
     it 'will return the date if list of comments includes text with the dates in the MM/DD/YYYY -MM/DD/YYYY format ', ->
       localMoment = moment("2016-03-21").toISOString(); #to get out of localization of test suite
-      prevMove = DateCommentHelpers.findPrevMoveDateFromComments({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
+      prevMove = DateCommentHelpers.extractNewCommentFromDate({"commentList": helpers.mockCommentCardObj.actions, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
       expect(prevMove).to.eql localMoment
       return
 
     it 'will return the last Action date is there is actionList and there is no date in the commentcard', ->
       comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
       comments[0].data.text = "This comment has no date."
-      prevMove = DateCommentHelpers.findPrevMoveDateFromComments({"commentList": comments, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
+      prevMove = DateCommentHelpers.extractNewCommentFromDate({"commentList": comments, "actionList": helpers.actionListMove, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
       expect(prevMove).to.eql '2016-02-25T22:00:35.866Z'
       return
 
     it 'will return the creation date if there is no actionList or no current comment', ->
       comments = JSON.parse(JSON.stringify(helpers.mockCommentCardObj.actions))
       comments[0].data.text = "This comment has no date."
-      prevMove = DateCommentHelpers.findPrevMoveDateFromComments({"commentList": comments, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
+      prevMove = DateCommentHelpers.extractNewCommentFromDate({"commentList": comments, "cardCreationDate": '2016-04-05T10:40:26.100Z'})
       expect(prevMove).to.eql '2016-04-05T10:40:26.100Z'
       return
 
@@ -86,7 +86,7 @@ describe 'app.DateCommentHelpers', ->
       comments = helpers.mockCommentCardObj.actions
       comments[0].data.text = "This comment has no date."
       localMoment = moment("2016-01-01").toISOString()
-      prevMove = DateCommentHelpers.findPrevMoveDateFromComments({})
+      prevMove = DateCommentHelpers.extractNewCommentFromDate({})
       expect(prevMove).to.eql localMoment
       return
     return

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -323,7 +323,7 @@ module.exports = {
             name: 'Comment Test Card',
             id: '322'
           },
-          text: '**Current Stage:** `+19 days`. *03/21/2016 - 03/08/2016*. Expected days: 2 days. Actual Days spent: 21.'
+          text: '**Current Stage:** `+19 days`. *03/08/2016 - 03/21/2016*. Expected days: 2 days. Actual Days spent: 21.'
         },
         type: 'commentCard',
         date: '2016-03-08T22:53:02.063Z',


### PR DESCRIPTION
Completely refactor the card recorder logic to conform to the following logic:
- [x] If in the final list of the board for over a day, no not do anything further.
- [x] Change the title of the comment based on if the card moved within the past 24 hours

     - [x] **Yes, card has moved w/in past 24 hours**
          * Comment will start with the *Name of the Last List Stage* (Grabbed from the last comment)
          * Date differences will be based off of the expected times for the previous stage/list

    - [x] **No**
          * Comment will start with the *Current Stage* (Grabbed from the last comment)
          * Date differences will be based off of the expected times for the current stage/list

- [x] The card will accommodate for edited toDates in the most recent comment.

     - [x] **No,** edits have been made the `toDate` on the most recent comment's written by `cardRecorder` (the To Date == yesterday)

          - [x] Accounts for if the most recent comment started with *Current* (Delete Current comment yields `true`)
              - *New Comment From Date:* **from** date of the most recent comment written by `cardRecorder`
              - *New Comment From Date:* The Current Time

          - [x] Accounts for if the most recent comments do not start with *Current* (Delete Current comment yields `false`)
              - *New Comment From Date:* **To** date of the most recent comment written by `cardRecorder`
              - *New Comment From Date:* The Current Time

     - [x] **Yes,** most recent comment's written by `cardRecorder` to date has been edited so it is no longer yesterday's date
          - *New Comment From Date:* **To** date of the most recent comment written by `cardRecorder`
          - *New Comment From Date:* The Current Time

- [X] Tests are updated

