### PR TITLE
Add health check type to manifest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,6 @@ npm start
 Run the Mocha/Chai tests run via Istanbul.
 `npm test`
 
-### Deployment
-Note that because the application is a worker [health checks must be disabled](https://docs.cloudfoundry.org/running/apps-enable-diego.html#disable-health-checks).
-`cf set-health-check trello-card-tracker none`
-
-
 ### Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
 - name: trello-card-tracker
   memory: 512M
-  buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.5.14
+  buildpack: nodejs_buildpack
   instances: 1
   no-route: true
+  health-check-type: none


### PR DESCRIPTION
I noticed the conversation about this in #cloud-gov-migration and checked out the resolution here. It's simpler and more reliable to set the health check type in the manifest than to remind operators to set the health check separately, so I suggested that change here. I also set the buildpack to the cached and up-to-date node buildpack, instead of pinning to an outdated buildpack.